### PR TITLE
refactor: Remove SQLx crate from torii-core

### DIFF
--- a/torii-auth-email/src/lib.rs
+++ b/torii-auth-email/src/lib.rs
@@ -253,8 +253,14 @@ mod tests {
         let mut manager = PluginManager::new(user_storage.clone(), session_storage.clone());
         manager.register(EmailPasswordPlugin::new(storage));
 
-        user_storage.migrate().await?;
-        session_storage.migrate().await?;
+        user_storage
+            .migrate()
+            .await
+            .map_err(|_| Error::Storage("Failed to migrate user storage".to_string()))?;
+        session_storage
+            .migrate()
+            .await
+            .map_err(|_| Error::Storage("Failed to migrate session storage".to_string()))?;
 
         Ok((manager,))
     }

--- a/torii-core/Cargo.toml
+++ b/torii-core/Cargo.toml
@@ -13,7 +13,6 @@ derive_builder.workspace = true
 downcast-rs = "2.0.1"
 futures.workspace = true
 serde.workspace = true
-sqlx.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 uuid.workspace = true

--- a/torii-core/src/error.rs
+++ b/torii-core/src/error.rs
@@ -2,10 +2,6 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    // Database errors
-    #[error("Database error: {0}")]
-    Database(#[from] sqlx::Error),
-
     // Plugin errors
     #[error("Plugin error: {0}")]
     Plugin(String),

--- a/torii-core/src/lib.rs
+++ b/torii-core/src/lib.rs
@@ -19,4 +19,4 @@ pub use error::Error;
 pub use plugin::{Plugin, PluginManager};
 pub use session::Session;
 pub use storage::{NewUser, SessionStorage, UserStorage};
-pub use user::{User, UserId};
+pub use user::{OAuthAccount, User, UserId};

--- a/torii-core/src/session.rs
+++ b/torii-core/src/session.rs
@@ -19,8 +19,7 @@ use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, sqlx::Type)]
-#[sqlx(transparent)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct SessionId(String);
 
 impl SessionId {
@@ -67,7 +66,7 @@ impl std::fmt::Display for SessionId {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow, Builder)]
+#[derive(Debug, Clone, Serialize, Deserialize, Builder)]
 pub struct Session {
     /// The unique identifier for the session.
     #[builder(default = "SessionId::new_random()")]

--- a/torii-core/src/user.rs
+++ b/torii-core/src/user.rs
@@ -18,8 +18,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 /// A unique, stable identifier for a specific user
-#[derive(Debug, Clone, PartialEq, Eq, sqlx::Type, Serialize, Deserialize, Hash)]
-#[sqlx(transparent)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct UserId(String);
 
 impl UserId {
@@ -70,7 +69,7 @@ impl std::fmt::Display for UserId {
 ///
 /// Many of these fields are optional, as they may not be available from the authentication provider,
 /// or may not be known at the time of authentication.
-#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow, Builder)]
+#[derive(Debug, Clone, Serialize, Deserialize, Builder)]
 pub struct User {
     // The unique identifier for the user.
     #[builder(default = "UserId::new_random()")]
@@ -98,6 +97,21 @@ pub struct User {
 impl User {
     pub fn builder() -> UserBuilder {
         UserBuilder::default()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Builder)]
+pub struct OAuthAccount {
+    pub user_id: UserId,
+    pub provider: String,
+    pub subject: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl OAuthAccount {
+    pub fn builder() -> OAuthAccountBuilder {
+        OAuthAccountBuilder::default()
     }
 }
 

--- a/torii/src/lib.rs
+++ b/torii/src/lib.rs
@@ -266,18 +266,34 @@ mod tests {
 
     async fn setup_torii() -> Result<Torii<SqliteStorage, SqliteStorage>, Error> {
         let _ = tracing_subscriber::fmt::try_init();
-        let pool = SqlitePool::connect("sqlite::memory:").await?;
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .map_err(|_| Error::Storage("Failed to connect to sqlite".to_string()))?;
         let torii = Torii::sqlite(pool.clone()).await?;
 
-        torii.manager.storage().user_storage().migrate().await?;
-        torii.manager.storage().session_storage().migrate().await?;
+        torii
+            .manager
+            .storage()
+            .user_storage()
+            .migrate()
+            .await
+            .map_err(|_| Error::Storage("Failed to migrate user storage".to_string()))?;
+        torii
+            .manager
+            .storage()
+            .session_storage()
+            .migrate()
+            .await
+            .map_err(|_| Error::Storage("Failed to migrate session storage".to_string()))?;
 
         Ok(torii)
     }
 
     async fn setup_torii_with_oauth() -> Result<Torii<SqliteStorage, SqliteStorage>, Error> {
         let _ = tracing_subscriber::fmt::try_init();
-        let pool = SqlitePool::connect("sqlite::memory:").await?;
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .map_err(|_| Error::Storage("Failed to connect to sqlite".to_string()))?;
         let torii = ToriiBuilder::<SqliteStorage, SqliteStorage>::new(
             Arc::new(SqliteStorage::new(pool.clone())),
             Arc::new(SqliteStorage::new(pool.clone())),
@@ -293,15 +309,29 @@ mod tests {
         )
         .build();
 
-        torii.manager.storage().user_storage().migrate().await?;
-        torii.manager.storage().session_storage().migrate().await?;
+        torii
+            .manager
+            .storage()
+            .user_storage()
+            .migrate()
+            .await
+            .map_err(|_| Error::Storage("Failed to migrate user storage".to_string()))?;
+        torii
+            .manager
+            .storage()
+            .session_storage()
+            .migrate()
+            .await
+            .map_err(|_| Error::Storage("Failed to migrate session storage".to_string()))?;
 
         Ok(torii)
     }
 
     #[tokio::test]
     async fn test_basic_setup() -> Result<(), Error> {
-        let pool = SqlitePool::connect("sqlite::memory:").await?;
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .map_err(|_| Error::Storage("Failed to connect to sqlite".to_string()))?;
 
         // Quick setup with defaults
         let _torii = Torii::sqlite(pool.clone()).await?;


### PR DESCRIPTION
This commit removes the `sqlx` crate from `torii-core` and removes the Error variant `Database`. Storages crates should use `Storage` variant instead.

I also moved the `OAuthStorage` trait out of `torii-storage-sqlite` and into `torii-core` to match the same structure as `torii-auth-email`