### PR TITLE
refactor: replace openidconnect with oauth2 library

### DIFF
--- a/torii-auth-oauth/Cargo.toml
+++ b/torii-auth-oauth/Cargo.toml
@@ -8,10 +8,12 @@ license.workspace = true
 [dependencies]
 torii-core = { path = "../torii-core" }
 
-openidconnect = "4.0.0"
+oauth2 = { version = "5.0.0" }
+reqwest = { version = "0.12", features = ["json"] }
 chrono.workspace = true
 async-trait.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 sqlx.workspace = true
 tracing.workspace = true
 uuid.workspace = true

--- a/torii-core/src/storage.rs
+++ b/torii-core/src/storage.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -92,16 +92,16 @@ pub trait OAuthStorage: UserStorage {
         subject: &str,
     ) -> Result<(), Self::Error>;
 
-    /// Retrieve a stored nonce by ID
-    async fn get_nonce(&self, id: &str) -> Result<Option<String>, Self::Error>;
-
-    /// Store a nonce with an expiration time
-    async fn save_nonce(
+    /// Store a PKCE verifier with an expiration time
+    async fn store_pkce_verifier(
         &self,
-        id: &str,
-        value: &str,
-        expires_at: &DateTime<Utc>,
-    ) -> Result<(), Self::Error>;
+        csrf_state: &str,
+        pkce_verifier: &str,
+        expires_in: Duration,
+    ) -> Result<(), Error>;
+
+    /// Retrieve a stored PKCE verifier by CSRF state
+    async fn get_pkce_verifier(&self, csrf_state: &str) -> Result<Option<String>, Error>;
 }
 
 #[derive(Debug, Clone)]

--- a/torii/src/lib.rs
+++ b/torii/src/lib.rs
@@ -129,13 +129,15 @@ where
     ///
     /// * `Self` - The builder instance
     #[cfg(feature = "oauth-auth")]
+    #[allow(clippy::too_many_arguments)]
     pub fn with_oauth_provider(
         mut self,
         provider: &str,
         client_id: &str,
         client_secret: &str,
         redirect_uri: &str,
-        issuer_url: &str,
+        auth_url: &str,
+        token_url: &str,
         scopes: &[&str],
     ) -> Self
     where
@@ -146,16 +148,16 @@ where
             self.manager.storage().user_storage(),
             self.manager.storage().session_storage(),
         );
-        self.manager
-            .register_auth_plugin(torii_auth_oauth::OAuthPlugin::new(
-                provider.to_string(),
-                client_id.to_string(),
-                client_secret.to_string(),
-                redirect_uri.to_string(),
-                issuer_url.to_string(),
-                scopes.iter().map(|s| s.to_string()).collect(),
-                storage,
-            ));
+        self.manager.register_auth_plugin(
+            torii_auth_oauth::OAuthPlugin::builder(provider, storage)
+                .client_id(client_id.to_string())
+                .client_secret(client_secret.to_string())
+                .redirect_uri(redirect_uri.to_string())
+                .auth_url(auth_url.to_string())
+                .token_url(token_url.to_string())
+                .add_scopes(scopes.iter().map(|s| s.to_string()).collect::<Vec<_>>())
+                .build(),
+        );
         self
     }
 
@@ -334,7 +336,8 @@ mod tests {
             "client_id",
             "client_secret",
             "redirect_uri",
-            "https://accounts.google.com",
+            "https://accounts.google.com/o/oauth2/v2/auth",
+            "https://www.googleapis.com/oauth2/v3/token",
             &["email", "profile"],
         )
         .build();


### PR DESCRIPTION
While the OIDC library is recommended, it would prevent us from using non-OIDC providers such as GitHub.

This implementation right now is only Google. Other providers will be added on a as needed basis.