### PR TITLE
feat(auth): add email verification support

### DIFF
--- a/torii-auth-email/examples/email_password.rs
+++ b/torii-auth-email/examples/email_password.rs
@@ -72,7 +72,7 @@ async fn sign_up_form_handler(
         .unwrap();
 
     match plugin
-        .register_user_with_password(&params.email, &params.password)
+        .register_user_with_password(&params.email, &params.password, None)
         .await
     {
         Ok(_) => (

--- a/torii-core/src/error.rs
+++ b/torii-core/src/error.rs
@@ -29,6 +29,9 @@ pub enum AuthError {
     #[error("User already exists")]
     UserAlreadyExists,
 
+    #[error("Email not verified")]
+    EmailNotVerified,
+
     #[error("Session not found")]
     SessionNotFound,
 

--- a/torii-core/src/storage.rs
+++ b/torii-core/src/storage.rs
@@ -206,8 +206,8 @@ impl NewUserBuilder {
         self
     }
 
-    pub fn email_verified_at(mut self, email_verified_at: DateTime<Utc>) -> Self {
-        self.email_verified_at = Some(email_verified_at);
+    pub fn email_verified_at(mut self, email_verified_at: Option<DateTime<Utc>>) -> Self {
+        self.email_verified_at = email_verified_at;
         self
     }
 

--- a/torii-core/src/user.rs
+++ b/torii-core/src/user.rs
@@ -99,6 +99,11 @@ impl User {
     pub fn builder() -> UserBuilder {
         UserBuilder::default()
     }
+
+    /// Check if the user's email has been verified.
+    pub fn is_email_verified(&self) -> bool {
+        self.email_verified_at.is_some() && self.email_verified_at.unwrap() < Utc::now()
+    }
 }
 
 #[derive(Default)]

--- a/torii/src/lib.rs
+++ b/torii/src/lib.rs
@@ -85,7 +85,7 @@ where
             .ok_or(ToriiError::PluginNotFound("email_password".to_string()))?;
 
         let user = password_plugin
-            .register_user_with_password(email, password)
+            .register_user_with_password(email, password, None)
             .await
             .map_err(|e| ToriiError::AuthError(e.to_string()))?;
 


### PR DESCRIPTION
- Modify `register_user_with_password` to accept optional email verification timestamp
- Add `is_email_verified` method to check email verification status
- Implement login prevention for unverified emails
- Update tests to cover email verification scenarios
- Add `EmailNotVerified` error variant to handle unverified email login attempts