### PR TITLE
Simplify logged in example routes

### DIFF
--- a/examples/todos/src/routes.rs
+++ b/examples/todos/src/routes.rs
@@ -226,6 +226,9 @@ async fn add_user_extension(
                 .get_user(&session.user_id)
                 .await
                 .expect("Failed to get user");
+            // Adding both User and Option<User> so that routes that need a logged in user can
+            // use Extension<User>, while routes that support both logged in and out
+            // can use Extension<Option<User>>
             request.extensions_mut().insert(user.clone());
             if let Some(valid_user) = user {
                 request.extensions_mut().insert(valid_user);


### PR DESCRIPTION
Trying to simplify the logged in routes a bit. 
verify_session already checks if User is Some/None, so each handler shouldn't need to.