### PR TITLE
Add new Magic Link Plugin 🪄

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Nothing yet.
+### Added
+
+#### `torii-auth-magic-link`
+
+A new plugin for generating and verifying magic links has been added.
+
+### Changed
+
+#### `torii-core`
+
+- `SessionStorage::get_session` now returns a `Result<Session, Error>` instead of `Result<Option<Session>, Error>`. Users should check the error for details on if the session was found, or expired.
+- Session creation, deletion, and cleanup are now handled by the `SessionManager` trait and the `DefaultSessionManager` implementation.
+- Plugins no longer require a `SessionStorage` parameter, the top level `Torii` struct now holds a `SessionManager` instance and login methods continue to return a `Session` instance.
+
+### Removed
+
+#### `torii-core`
+
+- `Storage<U,S>` struct has been removed. Use `Arc<U>` and `Arc<S>` directly instead.
+- `AsRef<UserId> and AsRef<SessionId>` have been removed. Use `as_str()` instead when needing a database serializable string.
 
 ## [0.2.0] - 2025-02-27
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "torii-auth-password",
     "torii-auth-oauth",
     "torii-auth-passkey",
+    "torii-auth-magic-link",
     "torii",
     "examples/todos",
 ]

--- a/examples/todos/src/routes.rs
+++ b/examples/todos/src/routes.rs
@@ -220,19 +220,17 @@ async fn add_user_extension(
             .await
             .expect("Failed to get session");
 
-        if let Some(session) = session {
-            let user = state
-                .torii
-                .get_user(&session.user_id)
-                .await
-                .expect("Failed to get user");
-            // Adding both User and Option<User> so that routes that need a logged in user can
-            // use Extension<User>, while routes that support both logged in and out
-            // can use Extension<Option<User>>
-            request.extensions_mut().insert(user.clone());
-            if let Some(valid_user) = user {
-                request.extensions_mut().insert(valid_user);
-            }
+        let user = state
+            .torii
+            .get_user(&session.user_id)
+            .await
+            .expect("Failed to get user");
+        // Adding both User and Option<User> so that routes that need a logged in user can
+        // use Extension<User>, while routes that support both logged in and out
+        // can use Extension<Option<User>>
+        request.extensions_mut().insert(user.clone());
+        if let Some(valid_user) = user {
+            request.extensions_mut().insert(valid_user);
         }
     }
     next.run(request).await
@@ -261,14 +259,13 @@ async fn whoami_handler(State(state): State<AppState>, jar: CookieJar) -> Respon
             .await
             .expect("Failed to get session");
 
-        if let Some(session) = session {
-            let user = state
-                .torii
-                .get_user(&session.user_id)
-                .await
-                .expect("Failed to get user");
-            return Json(user).into_response();
-        }
+        let user = state
+            .torii
+            .get_user(&session.user_id)
+            .await
+            .expect("Failed to get user");
+
+        return Json(user).into_response();
     }
 
     (

--- a/torii-auth-magic-link/Cargo.toml
+++ b/torii-auth-magic-link/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "torii-auth-magic-link"
+version = "0.1.0"
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+torii-core = { path = "../torii-core", version = "0.2" }
+thiserror.workspace = true
+rand = "0.9"
+base64 = "0.22"
+chrono.workspace = true
+[dev-dependencies]
+torii-storage-sqlite = { path = "../torii-storage-sqlite", version = "0.2" }
+tokio.workspace = true
+async-trait.workspace = true

--- a/torii-auth-magic-link/Cargo.toml
+++ b/torii-auth-magic-link/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "torii-auth-magic-link"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true
 
 [dependencies]
 torii-core = { path = "../torii-core", version = "0.2" }
-thiserror.workspace = true
-rand = "0.9"
 base64 = "0.22"
 chrono.workspace = true
+rand = "0.9"
+thiserror.workspace = true
 
 [dev-dependencies]
-torii-storage-sqlite = { path = "../torii-storage-sqlite", version = "0.2" }
+torii-storage-sqlite = { path = "../torii-storage-sqlite" }
 
 async-trait.workspace = true
 axum = { version = "0.8", features = ["macros"] }

--- a/torii-auth-magic-link/Cargo.toml
+++ b/torii-auth-magic-link/Cargo.toml
@@ -11,7 +11,20 @@ thiserror.workspace = true
 rand = "0.9"
 base64 = "0.22"
 chrono.workspace = true
+
 [dev-dependencies]
 torii-storage-sqlite = { path = "../torii-storage-sqlite", version = "0.2" }
-tokio.workspace = true
+
 async-trait.workspace = true
+axum = { version = "0.8", features = ["macros"] }
+axum-extra = { version = "0.10", features = ["cookie"] }
+serde_json.workspace = true
+serde.workspace = true
+sqlx.workspace = true
+tokio.workspace = true
+tracing-subscriber.workspace = true
+
+
+[[example]]
+name = "magic-link"
+path = "examples/magic_link.rs"

--- a/torii-auth-magic-link/examples/README.md
+++ b/torii-auth-magic-link/examples/README.md
@@ -1,0 +1,20 @@
+# Magic Link Example
+
+This example demonstrates how to use the Magic Link plugin to authenticate a user using an email and password.
+
+## Running the example
+
+```bash
+cargo run --example magic-link
+```
+
+## Accessing the example
+
+The example will start a server on `http://localhost:4000`. You can access the example by opening a browser and navigating to `http://localhost:4000/` and completing the form to create a new user.
+
+Once you have created a user, you can access the example by navigating to `http://localhost:4000/` and clicking the "Get Magic Link" button.
+
+Once signed in, you will be redirected to `http://localhost:4000/whoami` where you can view the user's details.
+
+> [!IMPORTANT]  
+> If you run the example multiple times, you will need to clear your cookies or use a different browser to test signing in with a different user.

--- a/torii-auth-magic-link/examples/magic_link.rs
+++ b/torii-auth-magic-link/examples/magic_link.rs
@@ -1,0 +1,266 @@
+use std::sync::Arc;
+
+use axum::{
+    Form, Json, Router,
+    body::Body,
+    extract::{Query, Request, State},
+    http::{StatusCode, header},
+    middleware::{self, Next},
+    response::{Html, IntoResponse, Redirect, Response},
+    routing::{get, post},
+};
+use axum_extra::extract::{
+    CookieJar,
+    cookie::{Cookie, SameSite},
+};
+use serde::Deserialize;
+use serde_json::json;
+use sqlx::{Pool, Sqlite};
+use torii_auth_magic_link::MagicLinkPlugin;
+use torii_core::{
+    Session,
+    plugin::PluginManager,
+    session::SessionId,
+    storage::{SessionStorage, UserStorage},
+};
+use torii_storage_sqlite::SqliteStorage;
+
+/// This example demonstrates how to set up a basic magic link authentication system using Torii.
+/// It creates a simple web server with:
+/// - Sign up page (/sign-up)
+/// - Sign in page (/sign-in)
+/// - Protected route (/whoami) that shows the authenticated user's details
+///
+/// The example uses:
+/// - SQLite for storing users and sessions (in memory database)
+/// - Axum web framework for routing and handling requests
+/// - MagicLinkPlugin from torii-auth-magic-link for authentication logic
+///
+/// Key concepts demonstrated:
+/// - Setting up storage backends (SqliteStorage)
+/// - Configuring the plugin system (PluginManager)
+/// - Session-based authentication with cookies
+/// - Protected routes using middleware
+#[derive(Deserialize)]
+struct SignUpForm {
+    email: String,
+}
+
+/// Form data for user registration
+#[derive(Deserialize)]
+struct SignInParams {
+    token: String,
+}
+
+/// Application state shared between route handlers
+/// Contains references to:
+/// - plugin_manager: Coordinates authentication plugins
+#[derive(Clone)]
+struct AppState {
+    plugin_manager: Arc<PluginManager<SqliteStorage, SqliteStorage>>,
+}
+
+/// Handles user registration
+/// 1. Extracts email from form submission
+/// 2. Creates new user via MagicLinkPlugin
+/// 3. Redirects to sign-in page on success
+#[axum::debug_handler]
+async fn generate_magic_link_handler(
+    State(state): State<AppState>,
+    Form(params): Form<SignUpForm>,
+) -> impl IntoResponse {
+    let plugin = state
+        .plugin_manager
+        .get_plugin::<MagicLinkPlugin<SqliteStorage>>("magic_link")
+        .unwrap();
+
+    let token = plugin.generate_magic_token(&params.email).await.unwrap();
+    let link = format!(
+        "http://localhost:4000/auth/magic-link/verify?token={}",
+        token.token
+    );
+    println!("Magic URL: {}", link);
+
+    (
+        StatusCode::OK,
+        // NOTE: DO NOT DO THIS IN PRODUCTION. THIS IS ONLY FOR DEMONSTRATION PURPOSES.
+        Html(format!(
+            r#"
+            <div style="max-width: 600px; margin: 40px auto; padding: 20px; font-family: sans-serif;">
+                <div style="padding: 15px; background-color: #fff3cd; border: 1px solid #ffeeba; border-radius: 4px; margin-bottom: 20px;">
+                    <strong>⚠️ WARNING:</strong> Displaying magic links directly in the response is insecure and should never be done in production.
+                </div>
+                <div style="text-align: center;">
+                    <p>For demonstration only:</p>
+                    <p>Please click the following link to sign in:</p>
+                    <a href='{}' style="display: inline-block; padding: 10px 20px; background-color: #007bff; color: white; text-decoration: none; border-radius: 4px;">{}</a>
+                </div>
+            </div>
+            "#,
+            link, link
+        )),
+    )
+        .into_response()
+}
+
+/// Handles user authentication
+/// 1. Validates magic link token
+/// 2. Creates a new session if valid
+/// 3. Sets session cookie and redirects to protected area
+#[axum::debug_handler]
+async fn verify_magic_link_handler(
+    State(state): State<AppState>,
+    Query(params): Query<SignInParams>,
+) -> impl IntoResponse {
+    let plugin: Arc<MagicLinkPlugin<SqliteStorage>> = state
+        .plugin_manager
+        .get_plugin::<MagicLinkPlugin<SqliteStorage>>("magic_link")
+        .unwrap();
+
+    let token = plugin.verify_magic_token(&params.token).await.unwrap();
+
+    let user = state
+        .plugin_manager
+        .user_storage()
+        .get_user(&token.user_id)
+        .await
+        .expect("get_user failed")
+        .expect("User not found");
+
+    let session = state
+        .plugin_manager
+        .session_storage()
+        .create_session(&Session::builder().user_id(user.id.clone()).build().unwrap())
+        .await
+        .expect("create_session failed");
+
+    let cookie = Cookie::build(("session_id", session.id.to_string()))
+        .path("/")
+        .http_only(true)
+        .secure(false) // TODO: Set to true in production
+        .same_site(SameSite::Lax);
+    (
+        [(header::SET_COOKIE, cookie.to_string())],
+        Redirect::to("/whoami"),
+    )
+        .into_response()
+}
+
+/// Middleware to protect routes that require authentication
+/// Checks for valid session cookie and redirects to sign-in if missing/invalid
+async fn verify_session<B>(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    request: Request,
+    next: Next,
+) -> Response {
+    let session_id = jar
+        .get("session_id")
+        .and_then(|cookie| cookie.value().parse::<String>().ok());
+
+    if let Some(session_id) = session_id {
+        // Verify session exists and is valid
+        state
+            .plugin_manager
+            .session_storage()
+            .get_session(&SessionId::new(&session_id))
+            .await
+            .unwrap();
+
+        return next.run(request).await;
+    }
+
+    // If session is invalid or missing, redirect to sign in
+    Redirect::to("/sign-in").into_response()
+}
+
+/// Protected route that displays the currently authenticated user's details
+/// Returns 401 if not authenticated
+async fn whoami_handler(State(state): State<AppState>, jar: CookieJar) -> Response {
+    let session_id = jar
+        .get("session_id")
+        .and_then(|cookie| cookie.value().parse::<String>().ok());
+
+    if let Some(session_id) = session_id {
+        let session = state
+            .plugin_manager
+            .session_storage()
+            .get_session(&SessionId::new(&session_id))
+            .await
+            .unwrap();
+
+        let user = state
+            .plugin_manager
+            .user_storage()
+            .get_user(&session.user_id)
+            .await
+            .unwrap();
+        return Json(user).into_response();
+    }
+
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(json!({
+            "error": "Not authenticated"
+        })),
+    )
+        .into_response()
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+    let pool = Pool::<Sqlite>::connect("sqlite::memory:").await.unwrap();
+
+    let user_storage = Arc::new(SqliteStorage::new(pool.clone()));
+    let session_storage = Arc::new(SqliteStorage::new(pool.clone()));
+
+    user_storage.migrate().await.unwrap();
+    session_storage.migrate().await.unwrap();
+
+    let mut plugin_manager = PluginManager::new(user_storage.clone(), session_storage.clone());
+    plugin_manager.register_plugin(MagicLinkPlugin::new(user_storage.clone()));
+    let plugin_manager = Arc::new(plugin_manager);
+
+    let app_state = AppState {
+        plugin_manager: plugin_manager.clone(),
+    };
+
+    let app = Router::new()
+        .route("/whoami", get(whoami_handler))
+        .route_layer(middleware::from_fn_with_state(
+            app_state.clone(),
+            verify_session::<Body>,
+        ))
+        .route(
+            "/",
+            get(|| async {
+                Html(
+                    r#"
+                <h1>Magic Link</h1>
+                <form action="/auth/magic-link/generate" method="post">
+                    <input type="email" name="email" placeholder="Email">
+                    <button type="submit">Get Magic Link</button>
+                </form>
+                "#,
+                )
+            }),
+        )
+        .route(
+            "/auth/magic-link/generate",
+            post(generate_magic_link_handler),
+        )
+        .route("/auth/magic-link/verify", get(verify_magic_link_handler))
+        .with_state(app_state.clone());
+
+    tokio::spawn(async move {
+        let listener = tokio::net::TcpListener::bind("0.0.0.0:4000").await.unwrap();
+        println!("Listening on {}", listener.local_addr().unwrap());
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    println!("Please open the following URL in your browser: http://localhost:4000/");
+
+    println!("Press Enter or Ctrl+C to exit...");
+    let _ = std::io::stdin().read_line(&mut String::new());
+}

--- a/torii-auth-magic-link/src/lib.rs
+++ b/torii-auth-magic-link/src/lib.rs
@@ -1,3 +1,32 @@
+//! Magic Link authentication plugin for Torii
+//!
+//! This plugin provides magic link authentication functionality, allowing users to sign in by clicking
+//! a secure link sent to their email address rather than using a password.
+//!
+//! # Features
+//!
+//! - Generate secure one-time use magic links
+//! - Verify magic link tokens
+//! - Automatic user creation if not exists
+//! - Configurable token expiration
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use torii_auth_magic_link::MagicLinkPlugin;
+//! use torii_core::plugin::PluginManager;
+//!
+//! // Register the plugin with your PluginManager
+//! let mut plugin_manager = PluginManager::new(user_storage.clone(), session_storage.clone());
+//! plugin_manager.register_plugin(MagicLinkPlugin::new(user_storage.clone()));
+//!
+//! // Generate a magic link token
+//! let plugin = plugin_manager.get_plugin::<MagicLinkPlugin>("magic_link").unwrap();
+//! let token = plugin.generate_magic_token("user@example.com").await?;
+//!
+//! // Verify the token when user clicks the link
+//! let user = plugin.verify_magic_token(&token.token).await?;
+//! ```
 use std::sync::Arc;
 
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
@@ -20,6 +49,34 @@ pub enum MagicLinkError {
     StorageError(String),
 }
 
+/// Magic Link authentication plugin
+///
+/// This plugin provides magic link authentication functionality, allowing users to sign in by clicking
+/// a secure link sent to their email address rather than using a password.
+///
+/// # Features
+///
+/// - Generate secure one-time use magic links
+/// - Verify magic link tokens
+/// - Automatic user creation if not exists
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use torii_auth_magic_link::MagicLinkPlugin;
+/// use torii_core::plugin::PluginManager;
+///
+/// // Register the plugin with your PluginManager
+/// let mut plugin_manager = PluginManager::new(user_storage.clone(), session_storage.clone());
+/// plugin_manager.register_plugin(MagicLinkPlugin::new(user_storage.clone()));
+///
+/// // Generate a magic link token
+/// let plugin = plugin_manager.get_plugin::<MagicLinkPlugin>("magic_link").unwrap();
+/// let token = plugin.generate_magic_token("user@example.com").await?;
+///
+/// // Verify the token when user clicks the link
+/// let user = plugin.verify_magic_token(&token.token).await?;
+/// ```
 pub struct MagicLinkPlugin<U: UserStorage> {
     user_storage: Arc<U>,
 }
@@ -81,6 +138,19 @@ where
     }
 }
 
+/// Generate a secure token
+///
+/// This function generates a secure token using the `rand` crate.
+/// The token is encoded using the `BASE64_URL_SAFE_NO_PAD` engine.
+///
+/// # Returns
+/// A secure token as a string
+///
+/// # Example
+///
+/// ```rust,no_run
+/// let token = generate_secure_token();
+/// ```
 fn generate_secure_token() -> String {
     let mut token = [0u8; 32];
     rand::rngs::OsRng

--- a/torii-auth-magic-link/src/lib.rs
+++ b/torii-auth-magic-link/src/lib.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
 use chrono::Utc;
 use rand::TryRngCore;
@@ -19,7 +21,7 @@ pub enum MagicLinkError {
 }
 
 pub struct MagicLinkPlugin<U: UserStorage> {
-    user_storage: U,
+    user_storage: Arc<U>,
 }
 
 impl<U> Plugin for MagicLinkPlugin<U>
@@ -35,7 +37,7 @@ impl<U> MagicLinkPlugin<U>
 where
     U: MagicLinkStorage,
 {
-    pub fn new(user_storage: U) -> Self {
+    pub fn new(user_storage: Arc<U>) -> Self {
         Self { user_storage }
     }
 
@@ -97,10 +99,10 @@ mod tests {
 
     use super::*;
 
-    async fn setup_sqlite_storage() -> SqliteStorage {
+    async fn setup_sqlite_storage() -> Arc<SqliteStorage> {
         let storage = SqliteStorage::connect("sqlite::memory:").await.unwrap();
         storage.migrate().await.unwrap();
-        storage
+        Arc::new(storage)
     }
 
     #[tokio::test]

--- a/torii-auth-magic-link/src/lib.rs
+++ b/torii-auth-magic-link/src/lib.rs
@@ -1,0 +1,135 @@
+use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+use chrono::Utc;
+use rand::TryRngCore;
+use torii_core::{
+    Plugin, UserStorage,
+    storage::{MagicLinkStorage, MagicToken},
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum MagicLinkError {
+    #[error("User not found")]
+    UserNotFound,
+
+    #[error("Token expired")]
+    TokenExpired,
+
+    #[error("Storage error: {0}")]
+    StorageError(String),
+}
+
+pub struct MagicLinkPlugin<U: UserStorage> {
+    user_storage: U,
+}
+
+impl<U> Plugin for MagicLinkPlugin<U>
+where
+    U: UserStorage,
+{
+    fn name(&self) -> String {
+        "magic_link".to_string()
+    }
+}
+
+impl<U> MagicLinkPlugin<U>
+where
+    U: MagicLinkStorage,
+{
+    pub fn new(user_storage: U) -> Self {
+        Self { user_storage }
+    }
+
+    pub async fn generate_magic_token(&self, email: &str) -> Result<MagicToken, MagicLinkError> {
+        let user = self
+            .user_storage
+            .get_or_create_user_by_email(email)
+            .await
+            .map_err(|e| MagicLinkError::StorageError(e.to_string()))?;
+
+        let now = Utc::now();
+        let token = MagicToken::new(
+            user.id,
+            generate_secure_token(),
+            now + chrono::Duration::minutes(10),
+            now,
+            now,
+        );
+
+        self.user_storage
+            .save_magic_token(&token)
+            .await
+            .map_err(|e| MagicLinkError::StorageError(e.to_string()))?;
+
+        Ok(token)
+    }
+
+    pub async fn verify_magic_token(&self, token: &str) -> Result<MagicToken, MagicLinkError> {
+        let token = self
+            .user_storage
+            .get_magic_token(token)
+            .await
+            .map_err(|e| MagicLinkError::StorageError(e.to_string()))?
+            .ok_or(MagicLinkError::UserNotFound)?;
+
+        if token.expires_at < Utc::now() {
+            return Err(MagicLinkError::TokenExpired);
+        }
+
+        Ok(token)
+    }
+}
+
+fn generate_secure_token() -> String {
+    let mut token = [0u8; 32];
+    rand::rngs::OsRng
+        .try_fill_bytes(&mut token)
+        .expect("Failed to generate secure bytes");
+    encode_token(&token)
+}
+
+fn encode_token(token: &[u8]) -> String {
+    BASE64_URL_SAFE_NO_PAD.encode(token)
+}
+
+#[cfg(test)]
+mod tests {
+    use torii_storage_sqlite::SqliteStorage;
+
+    use super::*;
+
+    async fn setup_sqlite_storage() -> SqliteStorage {
+        let storage = SqliteStorage::connect("sqlite::memory:").await.unwrap();
+        storage.migrate().await.unwrap();
+        storage
+    }
+
+    #[tokio::test]
+    async fn test_magic_link_plugin() {
+        let user_storage = setup_sqlite_storage().await;
+        let plugin = MagicLinkPlugin::new(user_storage);
+        assert_eq!(plugin.name(), "magic_link");
+    }
+
+    #[tokio::test]
+    async fn test_generate_magic_token() {
+        let user_storage = setup_sqlite_storage().await;
+        let plugin = MagicLinkPlugin::new(user_storage);
+        let token = plugin
+            .generate_magic_token("test@example.com")
+            .await
+            .unwrap();
+        assert_ne!(token.token, "");
+    }
+
+    #[tokio::test]
+    async fn test_verify_magic_token() {
+        let user_storage = setup_sqlite_storage().await;
+        let plugin = MagicLinkPlugin::new(user_storage);
+        let token = plugin
+            .generate_magic_token("test@example.com")
+            .await
+            .unwrap();
+        let verified_token = plugin.verify_magic_token(&token.token).await.unwrap();
+        assert_eq!(token, verified_token);
+    }
+}

--- a/torii-auth-oauth/examples/google/google.rs
+++ b/torii-auth-oauth/examples/google/google.rs
@@ -11,7 +11,7 @@ use axum_extra::extract::{CookieJar, cookie::Cookie};
 use serde::Deserialize;
 use sqlx::{Pool, Sqlite};
 use torii_auth_oauth::OAuthPlugin;
-use torii_core::{plugin::PluginManager, storage::Storage};
+use torii_core::{Session, plugin::PluginManager, storage::SessionStorage};
 use torii_storage_sqlite::SqliteStorage;
 
 #[derive(Debug, Deserialize)]
@@ -29,7 +29,7 @@ struct AppState {
 async fn login_handler(State(state): State<AppState>, jar: CookieJar) -> (CookieJar, Redirect) {
     let plugin = state
         .plugin_manager
-        .get_plugin::<OAuthPlugin<SqliteStorage, SqliteStorage>>("google")
+        .get_plugin::<OAuthPlugin<SqliteStorage>>("google")
         .unwrap();
 
     let auth_url = plugin.get_authorization_url().await.unwrap();
@@ -57,11 +57,18 @@ async fn callback_handler(
 
     let plugin = state
         .plugin_manager
-        .get_plugin::<OAuthPlugin<SqliteStorage, SqliteStorage>>("google")
+        .get_plugin::<OAuthPlugin<SqliteStorage>>("google")
         .unwrap();
 
-    let (user, session) = plugin
+    let user = plugin
         .exchange_code(params.code.to_string(), csrf_state.to_string())
+        .await
+        .unwrap();
+
+    let session = state
+        .plugin_manager
+        .session_storage()
+        .create_session(&Session::builder().user_id(user.id.clone()).build().unwrap())
         .await
         .unwrap();
 
@@ -88,14 +95,12 @@ async fn main() {
     user_storage.migrate().await.unwrap();
     session_storage.migrate().await.unwrap();
 
-    let storage = Storage::new(user_storage.clone(), session_storage.clone());
-
     let mut plugin_manager = PluginManager::new(user_storage.clone(), session_storage.clone());
     plugin_manager.register_plugin(OAuthPlugin::google(
         std::env::var("GOOGLE_CLIENT_ID").expect("GOOGLE_CLIENT_ID must be set"),
         std::env::var("GOOGLE_CLIENT_SECRET").expect("GOOGLE_CLIENT_SECRET must be set"),
         "http://localhost:4000/auth/google/callback".to_string(),
-        storage,
+        user_storage.clone(),
     ));
 
     let app = Router::new()

--- a/torii-core/src/error.rs
+++ b/torii-core/src/error.rs
@@ -16,6 +16,9 @@ pub enum Error {
 
     #[error("Event error: {0}")]
     Event(#[from] EventError),
+
+    #[error("Session error: {0}")]
+    Session(#[from] SessionError),
 }
 
 #[derive(Debug, Error)]
@@ -32,14 +35,20 @@ pub enum AuthError {
     #[error("Email not verified")]
     EmailNotVerified,
 
-    #[error("Session not found")]
-    SessionNotFound,
-
-    #[error("Session expired")]
-    SessionExpired,
-
     #[error("Unsupported authentication method: {0}")]
     UnsupportedMethod(String),
+}
+
+#[derive(Debug, Error)]
+pub enum SessionError {
+    #[error("Session not found")]
+    NotFound,
+
+    #[error("Session expired")]
+    Expired,
+
+    #[error("Session already exists")]
+    AlreadyExists,
 }
 
 #[derive(Debug, Error)]

--- a/torii-core/src/session.rs
+++ b/torii-core/src/session.rs
@@ -33,6 +33,10 @@ impl SessionId {
     pub fn into_inner(self) -> String {
         self.0
     }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
 impl Default for SessionId {
@@ -50,12 +54,6 @@ impl From<String> for SessionId {
 impl From<&str> for SessionId {
     fn from(s: &str) -> Self {
         Self(s.to_string())
-    }
-}
-
-impl AsRef<str> for SessionId {
-    fn as_ref(&self) -> &str {
-        &self.0
     }
 }
 

--- a/torii-core/src/storage.rs
+++ b/torii-core/src/storage.rs
@@ -261,3 +261,47 @@ pub trait PasskeyStorage: UserStorage {
         challenge_id: &str,
     ) -> Result<Option<String>, Self::Error>;
 }
+
+#[derive(Debug, Clone)]
+pub struct MagicToken {
+    pub user_id: UserId,
+    pub token: String,
+    pub expires_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl MagicToken {
+    pub fn new(
+        user_id: UserId,
+        token: String,
+        expires_at: DateTime<Utc>,
+        created_at: DateTime<Utc>,
+        updated_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            user_id,
+            token,
+            expires_at,
+            created_at,
+            updated_at,
+        }
+    }
+}
+
+impl PartialEq for MagicToken {
+    fn eq(&self, other: &Self) -> bool {
+        self.user_id == other.user_id
+            && self.token == other.token
+            // Some databases may not store the timestamp with more precision than seconds, so we compare the timestamps as integers
+            && self.expires_at.timestamp() == other.expires_at.timestamp()
+            && self.created_at.timestamp() == other.created_at.timestamp()
+            && self.updated_at.timestamp() == other.updated_at.timestamp()
+    }
+}
+
+#[async_trait]
+pub trait MagicLinkStorage: UserStorage {
+    async fn save_magic_token(&self, token: &MagicToken) -> Result<(), Self::Error>;
+    async fn get_magic_token(&self, token: &str) -> Result<Option<MagicToken>, Self::Error>;
+}

--- a/torii-core/src/user.rs
+++ b/torii-core/src/user.rs
@@ -38,6 +38,10 @@ impl UserId {
     pub fn as_uuid(&self) -> Uuid {
         Uuid::parse_str(&self.0).unwrap()
     }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
 impl Default for UserId {
@@ -55,12 +59,6 @@ impl From<String> for UserId {
 impl From<&str> for UserId {
     fn from(s: &str) -> Self {
         Self(s.to_string())
-    }
-}
-
-impl AsRef<str> for UserId {
-    fn as_ref(&self) -> &str {
-        &self.0
     }
 }
 
@@ -237,9 +235,9 @@ mod tests {
     #[test]
     fn test_user_id() {
         let user_id = UserId::new("test");
-        assert_eq!(user_id.as_ref(), "test");
+        assert_eq!(user_id.as_str(), "test");
 
-        let user_id_from_str = UserId::from(user_id.as_ref());
+        let user_id_from_str = UserId::from(user_id.as_str());
         assert_eq!(user_id_from_str, user_id);
 
         let user_id_random = UserId::new_random();

--- a/torii-storage-postgres/src/lib.rs
+++ b/torii-storage-postgres/src/lib.rs
@@ -106,7 +106,7 @@ impl UserStorage for PostgresStorage {
             RETURNING id::text, email, name, email_verified_at, created_at, updated_at
             "#,
         )
-        .bind(user.id.as_ref())
+        .bind(user.id.as_str())
         .bind(&user.email)
         .fetch_one(&self.pool)
         .await
@@ -126,7 +126,7 @@ impl UserStorage for PostgresStorage {
             WHERE id::text = $1
             "#,
         )
-        .bind(id.as_ref())
+        .bind(id.as_str())
         .fetch_optional(&self.pool)
         .await
         .map_err(|e| {
@@ -198,7 +198,7 @@ impl UserStorage for PostgresStorage {
         .bind(&user.name)
         .bind(user.email_verified_at)
         .bind(user.updated_at)
-        .bind(user.id.as_ref())
+        .bind(user.id.as_str())
         .fetch_one(&self.pool)
         .await
         .map_err(|e| {
@@ -211,7 +211,7 @@ impl UserStorage for PostgresStorage {
 
     async fn delete_user(&self, id: &UserId) -> Result<(), Self::Error> {
         sqlx::query("DELETE FROM users WHERE id::text = $1")
-            .bind(id.as_ref())
+            .bind(id.as_str())
             .execute(&self.pool)
             .await
             .map_err(|e| {
@@ -225,7 +225,7 @@ impl UserStorage for PostgresStorage {
     async fn set_user_email_verified(&self, user_id: &UserId) -> Result<(), Self::Error> {
         sqlx::query("UPDATE users SET email_verified_at = $1 WHERE id::text = $2")
             .bind(Utc::now())
-            .bind(user_id.as_ref())
+            .bind(user_id.as_str())
             .execute(&self.pool)
             .await
             .map_err(|e| {

--- a/torii-storage-postgres/src/oauth.rs
+++ b/torii-storage-postgres/src/oauth.rs
@@ -125,7 +125,7 @@ impl OAuthStorage for PostgresStorage {
         user_id: &UserId,
     ) -> Result<OAuthAccount, Self::Error> {
         sqlx::query("INSERT INTO oauth_accounts (user_id, provider, subject, created_at, updated_at) VALUES ($1::uuid, $2, $3, $4, $5)")
-            .bind(user_id.as_ref())
+            .bind(user_id.as_str())
             .bind(provider)
             .bind(subject)
             .bind(Utc::now())
@@ -144,7 +144,7 @@ impl OAuthStorage for PostgresStorage {
             WHERE user_id::text = $1
             "#,
         )
-        .bind(user_id.as_ref())
+        .bind(user_id.as_str())
         .fetch_one(&self.pool)
         .await
         .map_err(|e| {
@@ -254,7 +254,7 @@ impl OAuthStorage for PostgresStorage {
         subject: &str,
     ) -> Result<(), Self::Error> {
         sqlx::query("INSERT INTO oauth_accounts (user_id, provider, subject, created_at, updated_at) VALUES ($1::uuid, $2, $3, $4, $5)")
-            .bind(user_id.as_ref())
+            .bind(user_id.as_str())
             .bind(provider)
             .bind(subject)
             .bind(Utc::now())

--- a/torii-storage-postgres/src/passkey.rs
+++ b/torii-storage-postgres/src/passkey.rs
@@ -20,7 +20,7 @@ impl PasskeyStorage for PostgresStorage {
             "#,
         )
         .bind(credential_id)
-        .bind(user_id.as_ref())
+        .bind(user_id.as_str())
         .bind(passkey_json)
         .execute(&self.pool)
         .await
@@ -54,7 +54,7 @@ impl PasskeyStorage for PostgresStorage {
             WHERE user_id = $1::uuid
             "#,
         )
-        .bind(user_id.as_ref())
+        .bind(user_id.as_str())
         .fetch_all(&self.pool)
         .await
         .map_err(|e| StorageError::Database(e.to_string()))?;

--- a/torii-storage-postgres/src/password.rs
+++ b/torii-storage-postgres/src/password.rs
@@ -13,7 +13,7 @@ impl PasswordStorage for PostgresStorage {
     ) -> Result<(), torii_core::Error> {
         sqlx::query("UPDATE users SET password_hash = $1 WHERE id::text = $2")
             .bind(hash)
-            .bind(user_id.as_ref())
+            .bind(user_id.as_str())
             .execute(&self.pool)
             .await
             .map_err(|_| StorageError::Database("Failed to set password hash".to_string()))?;
@@ -25,7 +25,7 @@ impl PasswordStorage for PostgresStorage {
         user_id: &UserId,
     ) -> Result<Option<String>, torii_core::Error> {
         let result = sqlx::query_scalar("SELECT password_hash FROM users WHERE id::text = $1")
-            .bind(user_id.as_ref())
+            .bind(user_id.as_str())
             .fetch_optional(&self.pool)
             .await
             .map_err(|_| StorageError::Database("Failed to get password hash".to_string()))?;

--- a/torii-storage-postgres/src/session.rs
+++ b/torii-storage-postgres/src/session.rs
@@ -51,8 +51,8 @@ impl SessionStorage for PostgresStorage {
 
     async fn create_session(&self, session: &Session) -> Result<Session, Self::Error> {
         sqlx::query("INSERT INTO sessions (id, user_id, user_agent, ip_address, created_at, updated_at, expires_at) VALUES ($1::uuid, $2::uuid, $3, $4, $5, $6, $7)")
-            .bind(session.id.as_ref())
-            .bind(session.user_id.as_ref())
+            .bind(session.id.as_str())
+            .bind(session.user_id.as_str())
             .bind(&session.user_agent)
             .bind(&session.ip_address)
             .bind(session.created_at)
@@ -76,7 +76,7 @@ impl SessionStorage for PostgresStorage {
             WHERE id::text = $1
             "#,
         )
-        .bind(id.as_ref())
+        .bind(id.as_str())
         .fetch_one(&self.pool)
         .await
         .map_err(|e| {
@@ -89,7 +89,7 @@ impl SessionStorage for PostgresStorage {
 
     async fn delete_session(&self, id: &SessionId) -> Result<(), Self::Error> {
         sqlx::query("DELETE FROM sessions WHERE id::text = $1")
-            .bind(id.as_ref())
+            .bind(id.as_str())
             .execute(&self.pool)
             .await
             .map_err(|e| {
@@ -115,7 +115,7 @@ impl SessionStorage for PostgresStorage {
 
     async fn delete_sessions_for_user(&self, user_id: &UserId) -> Result<(), Self::Error> {
         sqlx::query("DELETE FROM sessions WHERE user_id::text = $1")
-            .bind(user_id.as_ref())
+            .bind(user_id.as_str())
             .execute(&self.pool)
             .await
             .map_err(|e| {

--- a/torii-storage-postgres/src/session.rs
+++ b/torii-storage-postgres/src/session.rs
@@ -65,10 +65,10 @@ impl SessionStorage for PostgresStorage {
                 StorageError::Database("Failed to create session".to_string())
             })?;
 
-        Ok(self.get_session(&session.id).await?.unwrap())
+        Ok(self.get_session(&session.id).await?)
     }
 
-    async fn get_session(&self, id: &SessionId) -> Result<Option<Session>, Self::Error> {
+    async fn get_session(&self, id: &SessionId) -> Result<Session, Self::Error> {
         let session = sqlx::query_as::<_, PostgresSession>(
             r#"
             SELECT id::text, user_id::text, user_agent, ip_address, created_at, updated_at, expires_at
@@ -84,7 +84,7 @@ impl SessionStorage for PostgresStorage {
             StorageError::Database("Failed to get session".to_string())
         })?;
 
-        Ok(Some(session.into()))
+        Ok(session.into())
     }
 
     async fn delete_session(&self, id: &SessionId) -> Result<(), Self::Error> {
@@ -184,8 +184,7 @@ mod test {
         let fetched = storage
             .get_session(&session_id)
             .await
-            .expect("Failed to get session")
-            .expect("Session should exist");
+            .expect("Failed to get session");
         assert_eq!(fetched.user_id, user_id);
 
         storage
@@ -244,8 +243,7 @@ mod test {
         let valid_session = storage
             .get_session(&session_id)
             .await
-            .expect("Failed to get valid session")
-            .expect("Session should exist");
+            .expect("Failed to get valid session");
         assert_eq!(valid_session.user_id, user_id);
     }
 
@@ -311,6 +309,6 @@ mod test {
             .get_session(&session_id3)
             .await
             .expect("Failed to get session 3");
-        assert!(session3.is_some());
+        assert_eq!(session3.user_id, user_id2);
     }
 }

--- a/torii-storage-sqlite/src/magic_link.rs
+++ b/torii-storage-sqlite/src/magic_link.rs
@@ -1,0 +1,74 @@
+use async_trait::async_trait;
+use chrono::DateTime;
+use torii_core::{
+    UserId,
+    error::StorageError,
+    storage::{MagicLinkStorage, MagicToken},
+};
+
+use crate::SqliteStorage;
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct SqliteMagicToken {
+    pub id: Option<String>,
+    pub user_id: String,
+    pub token: String,
+    pub expires_at: i64,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+impl From<SqliteMagicToken> for MagicToken {
+    fn from(row: SqliteMagicToken) -> Self {
+        MagicToken::new(
+            UserId::new(&row.user_id),
+            row.token.clone(),
+            DateTime::from_timestamp(row.expires_at, 0).unwrap(),
+            DateTime::from_timestamp(row.created_at, 0).unwrap(),
+            DateTime::from_timestamp(row.updated_at, 0).unwrap(),
+        )
+    }
+}
+
+impl From<&MagicToken> for SqliteMagicToken {
+    fn from(token: &MagicToken) -> Self {
+        SqliteMagicToken {
+            id: None,
+            user_id: token.user_id.as_str().to_string(),
+            token: token.token.clone(),
+            expires_at: token.expires_at.timestamp(),
+            created_at: token.created_at.timestamp(),
+            updated_at: token.updated_at.timestamp(),
+        }
+    }
+}
+
+#[async_trait]
+impl MagicLinkStorage for SqliteStorage {
+    async fn save_magic_token(&self, token: &MagicToken) -> Result<(), StorageError> {
+        let row = SqliteMagicToken::from(token);
+
+        sqlx::query("INSERT INTO magic_links (user_id, token, expires_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?)")
+            .bind(row.user_id)
+            .bind(row.token)
+            .bind(row.expires_at)
+            .bind(row.created_at)
+            .bind(row.updated_at)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::Database(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn get_magic_token(&self, token: &str) -> Result<Option<MagicToken>, StorageError> {
+        let row: Option<SqliteMagicToken> =
+            sqlx::query_as("SELECT id, user_id, token, expires_at, created_at, updated_at FROM magic_links WHERE token = ?")
+                .bind(token)
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(|e| StorageError::Database(e.to_string()))?;
+
+        Ok(row.map(|row| row.into()))
+    }
+}

--- a/torii-storage-sqlite/src/oauth.rs
+++ b/torii-storage-sqlite/src/oauth.rs
@@ -59,7 +59,7 @@ impl OAuthStorage for SqliteStorage {
             RETURNING user_id, provider, subject, created_at, updated_at
             "#,
         )
-        .bind(user_id.as_ref())
+        .bind(user_id.as_str())
         .bind(provider)
         .bind(subject)
         .bind(now.timestamp())
@@ -138,7 +138,7 @@ impl OAuthStorage for SqliteStorage {
     ) -> Result<(), Self::Error> {
         let now = Utc::now();
         sqlx::query("INSERT INTO oauth_accounts (user_id, provider, subject, created_at, updated_at) VALUES (?, ?, ?, ?, ?)")
-            .bind(user_id.as_ref())
+            .bind(user_id.as_str())
             .bind(provider)
             .bind(subject)
             .bind(now.timestamp())

--- a/torii-storage-sqlite/src/passkey.rs
+++ b/torii-storage-sqlite/src/passkey.rs
@@ -20,7 +20,7 @@ impl PasskeyStorage for SqliteStorage {
             "#,
         )
         .bind(credential_id)
-        .bind(user_id.as_ref())
+        .bind(user_id.as_str())
         .bind(passkey_json)
         .execute(&self.pool)
         .await
@@ -54,7 +54,7 @@ impl PasskeyStorage for SqliteStorage {
             WHERE user_id = ?
             "#,
         )
-        .bind(user_id.as_ref())
+        .bind(user_id.as_str())
         .fetch_all(&self.pool)
         .await
         .map_err(|e| StorageError::Database(e.to_string()))?;

--- a/torii-storage-sqlite/src/password.rs
+++ b/torii-storage-sqlite/src/password.rs
@@ -9,7 +9,7 @@ impl PasswordStorage for SqliteStorage {
     async fn set_password_hash(&self, user_id: &UserId, hash: &str) -> Result<(), StorageError> {
         sqlx::query("UPDATE users SET password_hash = $1 WHERE id = $2")
             .bind(hash)
-            .bind(user_id.as_ref())
+            .bind(user_id.as_str())
             .execute(&self.pool)
             .await
             .map_err(|e| StorageError::Database(e.to_string()))?;
@@ -18,7 +18,7 @@ impl PasswordStorage for SqliteStorage {
 
     async fn get_password_hash(&self, user_id: &UserId) -> Result<Option<String>, StorageError> {
         let result = sqlx::query_scalar("SELECT password_hash FROM users WHERE id = $1")
-            .bind(user_id.as_ref())
+            .bind(user_id.as_str())
             .fetch_optional(&self.pool)
             .await
             .map_err(|e| StorageError::Database(e.to_string()))?;

--- a/torii-storage-sqlite/src/session.rs
+++ b/torii-storage-sqlite/src/session.rs
@@ -74,7 +74,7 @@ impl SessionStorage for SqliteStorage {
         Ok(session.into())
     }
 
-    async fn get_session(&self, id: &SessionId) -> Result<Option<Session>, Self::Error> {
+    async fn get_session(&self, id: &SessionId) -> Result<Session, Self::Error> {
         let session = sqlx::query_as::<_, SqliteSession>(
             r#"
             SELECT id, user_id, user_agent, ip_address, created_at, updated_at, expires_at
@@ -90,7 +90,7 @@ impl SessionStorage for SqliteStorage {
             StorageError::Database("Failed to get session".to_string())
         })?;
 
-        Ok(Some(session.into()))
+        Ok(session.into())
     }
 
     async fn delete_session(&self, id: &SessionId) -> Result<(), Self::Error> {
@@ -178,8 +178,7 @@ pub(crate) mod test {
         let fetched = storage
             .get_session(&SessionId::new("1"))
             .await
-            .expect("Failed to get session")
-            .expect("Session should exist");
+            .expect("Failed to get session");
         assert_eq!(fetched.user_id, UserId::new("1"));
 
         storage
@@ -234,7 +233,7 @@ pub(crate) mod test {
             .get_session(&SessionId::new("valid"))
             .await
             .expect("Failed to get valid session");
-        assert!(valid_session.is_some());
+        assert_eq!(valid_session.user_id, UserId::new("1"));
     }
 
     #[tokio::test]
@@ -281,6 +280,6 @@ pub(crate) mod test {
             .get_session(&SessionId::new("session3"))
             .await
             .expect("Failed to get session 3");
-        assert!(session3.is_some());
+        assert_eq!(session3.user_id, UserId::new("2"));
     }
 }

--- a/torii-storage-sqlite/src/session.rs
+++ b/torii-storage-sqlite/src/session.rs
@@ -57,8 +57,8 @@ impl SessionStorage for SqliteStorage {
             RETURNING id, user_id, user_agent, ip_address, created_at, updated_at, expires_at
             "#,
         )
-            .bind(session.id.as_ref())
-            .bind(session.user_id.as_ref())
+            .bind(session.id.as_str())
+            .bind(session.user_id.as_str())
             .bind(&session.user_agent)
             .bind(&session.ip_address)
             .bind(session.created_at.timestamp())
@@ -82,7 +82,7 @@ impl SessionStorage for SqliteStorage {
             WHERE id = ?
             "#,
         )
-        .bind(id.as_ref())
+        .bind(id.as_str())
         .fetch_one(&self.pool)
         .await
         .map_err(|e| {
@@ -95,7 +95,7 @@ impl SessionStorage for SqliteStorage {
 
     async fn delete_session(&self, id: &SessionId) -> Result<(), Self::Error> {
         sqlx::query("DELETE FROM sessions WHERE id = ?")
-            .bind(id.as_ref())
+            .bind(id.as_str())
             .execute(&self.pool)
             .await
             .map_err(|e| {
@@ -121,7 +121,7 @@ impl SessionStorage for SqliteStorage {
 
     async fn delete_sessions_for_user(&self, user_id: &UserId) -> Result<(), Self::Error> {
         sqlx::query("DELETE FROM sessions WHERE user_id = ?")
-            .bind(user_id.as_ref())
+            .bind(user_id.as_str())
             .execute(&self.pool)
             .await
             .map_err(|e| {

--- a/torii/Cargo.toml
+++ b/torii/Cargo.toml
@@ -14,6 +14,7 @@ torii-auth-passkey = { path = "../torii-auth-passkey", version = "0.2.1", option
 torii-storage-sqlite = { path = "../torii-storage-sqlite", version = "0.2.1", optional = true }
 torii-storage-postgres = { path = "../torii-storage-postgres", version = "0.2.1", optional = true }
 
+chrono.workspace = true # TODO: Make this optional and expose std::time::Duration in APIs
 tracing.workspace = true
 thiserror.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
We’re adding a new plugin for generating and verifying magic links. Unlike other plugins, this one doesn’t depend on a specific mail provider. Instead, the user is responsible for creating and sending the email.

However, when using this plugin, it’s important to handle tokens carefully. Ideally, the verification endpoint should require some user interaction, such as clicking a button after opening the link to complete the verification. Using a `GET`-only approach might allow email link scanners to access the link and obtain a valid session, while also consuming the link.

The following things are still needed before I merge this plugin:

- [ ] Postgres support
- [ ] Token consumption after use (i.e, this link has already been used or expired)

Closes #22 