### PR TITLE
Add SeaORM as a storage provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+Added a new crate, `torii-storage-seaorm`, which is a storage backend for the torii authentication ecosystem that uses SeaORM to target SQLite, Postgres, and MySQL.
+
 ### Changed
 
 #### `torii-core`
@@ -35,6 +39,8 @@ A new plugin for generating and verifying magic links has been added.
 
 - `Storage<U,S>` struct has been removed. Use `Arc<U>` and `Arc<S>` directly instead.
 - `AsRef<UserId> and AsRef<SessionId>` have been removed. Use `as_str()` instead when needing a database serializable string.
+
+---
 
 ## [0.2.0] - 2025-02-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No changes yet.
+### Changed
+
+#### `torii-core`
+
+- `SessionStorage::get_session` now returns a `Result<Option<Session>, Error>` instead of `Result<Session, Error>`. This reverts the change from `0.2.3`.
 
 ## [0.2.3] - 2025-03-05
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "torii-migration",
     "torii-storage-sqlite",
     "torii-storage-postgres",
+    "torii-storage-seaorm",
     "torii-auth-password",
     "torii-auth-oauth",
     "torii-auth-passkey",

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 [![docs.rs](https://img.shields.io/docsrs/torii)](https://docs.rs/torii/latest/torii/)
 [![Crates.io Version](https://img.shields.io/crates/v/torii)](https://crates.io/crates/torii)
 
-![Torii Logo](./assets/splash.jpeg)
-
 > [!WARNING]
 > This project is in early development and is not production-ready. The API is subject to change without notice.
 

--- a/examples/todos/Cargo.toml
+++ b/examples/todos/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 # torii
 torii = { path = "../../torii", version = "0.2.3", features = [
     "password",
-    "sqlite",
+    "seaorm-sqlite",
 ] }
 
 # web server
@@ -24,6 +24,6 @@ uuid = { version = "1.13.1", features = ["v4", "v7"] }
 
 # async/runtime
 dashmap = "6.0"
-sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio"] }
 tokio = { version = "1.0", features = ["full"] }
 tracing-subscriber = "0.3"
+tracing.workspace = true

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -1,6 +1,6 @@
 use dashmap::DashMap;
 use std::sync::Arc;
-use torii::{SqliteStorage, Torii};
+use torii::{SeaORMStorage, Torii};
 
 mod routes;
 mod templates;
@@ -10,7 +10,7 @@ mod templates;
 /// - plugin_manager: Coordinates authentication plugins
 #[derive(Clone)]
 pub(crate) struct AppState {
-    torii: Arc<Torii<SqliteStorage, SqliteStorage>>,
+    torii: Arc<Torii<SeaORMStorage, SeaORMStorage>>,
     todos: Arc<DashMap<String, Todo>>,
 }
 
@@ -27,12 +27,12 @@ async fn main() {
     tracing_subscriber::fmt::init();
 
     let user_storage = Arc::new(
-        SqliteStorage::connect("sqlite://todos.db?mode=rwc")
+        SeaORMStorage::connect("sqlite://todos.db?mode=rwc")
             .await
             .expect("Failed to connect to database"),
     );
     let session_storage = Arc::new(
-        SqliteStorage::connect("sqlite://todos.db?mode=rwc")
+        SeaORMStorage::connect("sqlite://todos.db?mode=rwc")
             .await
             .expect("Failed to connect to database"),
     );

--- a/examples/todos/src/routes.rs
+++ b/examples/todos/src/routes.rs
@@ -14,6 +14,7 @@ use axum_extra::extract::{
 use serde::Deserialize;
 use serde_json::json;
 use torii::{SessionId, User};
+use tracing::info;
 use uuid::Uuid;
 
 use crate::{
@@ -158,6 +159,8 @@ async fn sign_up_form_handler(
         .register_user_with_password(&params.email, &params.password)
         .await;
 
+    info!("User registered: {:?}", user);
+
     match user {
         Ok(_) => (
             StatusCode::OK,
@@ -189,7 +192,7 @@ async fn sign_in_form_handler(
         .await
         .unwrap();
 
-    let cookie = Cookie::build(("session_id", session.id.to_string()))
+    let cookie = Cookie::build(("session_id", session.token.to_string()))
         .path("/")
         .http_only(true)
         .secure(false) // TODO: Set to true in production

--- a/torii-auth-magic-link/Cargo.toml
+++ b/torii-auth-magic-link/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "torii-auth-magic-link"
 description = "Magic Link authentication plugin for Torii"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/torii-auth-magic-link/examples/magic_link.rs
+++ b/torii-auth-magic-link/examples/magic_link.rs
@@ -206,7 +206,7 @@ async fn whoami_handler(State(state): State<AppState>, jar: CookieJar) -> Respon
     let user = state
         .plugin_manager
         .user_storage()
-        .get_user(&session.user_id)
+        .get_user(&session.unwrap().user_id)
         .await
         .unwrap();
 

--- a/torii-auth-magic-link/examples/magic_link.rs
+++ b/torii-auth-magic-link/examples/magic_link.rs
@@ -136,7 +136,7 @@ async fn verify_magic_link_handler(
         .await
         .expect("create_session failed");
 
-    let cookie = Cookie::build(("session_id", session.id.to_string()))
+    let cookie = Cookie::build(("session_id", session.token.to_string()))
         .path("/")
         .http_only(true)
         .secure(false) // TODO: Set to true in production

--- a/torii-auth-oauth/examples/github/github.rs
+++ b/torii-auth-oauth/examples/github/github.rs
@@ -79,7 +79,7 @@ async fn callback_handler(
 
     // Set session cookie
     let jar = jar.add(
-        Cookie::build(("session_id", session.id.to_string()))
+        Cookie::build(("session_id", session.token.to_string()))
             .path("/")
             .http_only(true),
     );

--- a/torii-auth-oauth/examples/google/google.rs
+++ b/torii-auth-oauth/examples/google/google.rs
@@ -74,7 +74,7 @@ async fn callback_handler(
 
     // Set session cookie
     let jar = jar.add(
-        Cookie::build(("session_id", session.id.to_string()))
+        Cookie::build(("session_id", session.token.to_string()))
             .path("/")
             .http_only(true),
     );

--- a/torii-auth-passkey/examples/passkey.rs
+++ b/torii-auth-passkey/examples/passkey.rs
@@ -128,7 +128,7 @@ async fn whoami_handler(State(state): State<AppState>, jar: CookieJar) -> Respon
         let user = state
             .plugin_manager
             .user_storage()
-            .get_user(&session.user_id)
+            .get_user(&session.unwrap().user_id)
             .await
             .unwrap();
         return Json(user).into_response();

--- a/torii-auth-passkey/examples/passkey.rs
+++ b/torii-auth-passkey/examples/passkey.rs
@@ -102,7 +102,7 @@ async fn finish_registration_handler(
         .unwrap();
 
     let jar = jar.add(
-        Cookie::build(("session_id", session.id.to_string()))
+        Cookie::build(("session_id", session.token.to_string()))
             .path("/")
             .http_only(true),
     );
@@ -230,7 +230,7 @@ async fn finish_login_handler(
         .unwrap();
 
     let jar = jar.add(
-        Cookie::build(("session_id", session.id.to_string()))
+        Cookie::build(("session_id", session.token.to_string()))
             .path("/")
             .http_only(true),
     );

--- a/torii-auth-password/examples/password.rs
+++ b/torii-auth-password/examples/password.rs
@@ -208,7 +208,7 @@ async fn whoami_handler(State(state): State<AppState>, jar: CookieJar) -> Respon
         let user = state
             .plugin_manager
             .user_storage()
-            .get_user(&session.user_id)
+            .get_user(&session.unwrap().user_id)
             .await
             .unwrap();
         return Json(user).into_response();

--- a/torii-auth-password/examples/password.rs
+++ b/torii-auth-password/examples/password.rs
@@ -121,7 +121,7 @@ async fn sign_in_form_handler(
         .await
         .unwrap();
 
-    let cookie = Cookie::build(("session_id", session.id.to_string()))
+    let cookie = Cookie::build(("session_id", session.token.to_string()))
         .path("/")
         .http_only(true)
         .secure(false) // TODO: Set to true in production

--- a/torii-core/src/events.rs
+++ b/torii-core/src/events.rs
@@ -280,7 +280,7 @@ mod tests {
             Event::UserUpdated(test_user.clone()),
             Event::UserDeleted(test_user.id.clone()),
             Event::SessionCreated(test_user.id.clone(), test_session.clone()),
-            Event::SessionDeleted(test_user.id.clone(), test_session.id.clone()),
+            Event::SessionDeleted(test_user.id.clone(), test_session.token.clone()),
         ];
 
         for event in events {

--- a/torii-core/src/plugin.rs
+++ b/torii-core/src/plugin.rs
@@ -241,7 +241,7 @@ mod tests {
         }
 
         async fn create_session(&self, session: &Session) -> Result<Session, Self::Error> {
-            self.sessions.insert(session.id.clone(), session.clone());
+            self.sessions.insert(session.token.clone(), session.clone());
             Ok(session.clone())
         }
 
@@ -285,7 +285,7 @@ mod tests {
 
         // Create an expired session
         let expired_session = Session {
-            id: SessionId::new("expired"),
+            token: SessionId::new("expired"),
             user_id: UserId::new("test"),
             user_agent: None,
             ip_address: None,
@@ -300,7 +300,7 @@ mod tests {
 
         // Create a valid session
         let valid_session = Session {
-            id: SessionId::new("valid"),
+            token: SessionId::new("valid"),
             user_id: UserId::new("test"),
             user_agent: None,
             ip_address: None,

--- a/torii-core/src/plugin.rs
+++ b/torii-core/src/plugin.rs
@@ -236,8 +236,8 @@ mod tests {
     impl SessionStorage for TestStorage {
         type Error = Error;
 
-        async fn get_session(&self, id: &SessionId) -> Result<Session, Self::Error> {
-            Ok(self.sessions.get(id).unwrap().clone())
+        async fn get_session(&self, id: &SessionId) -> Result<Option<Session>, Self::Error> {
+            Ok(self.sessions.get(id).map(|s| s.clone()))
         }
 
         async fn create_session(&self, session: &Session) -> Result<Session, Self::Error> {

--- a/torii-core/src/session.rs
+++ b/torii-core/src/session.rs
@@ -224,12 +224,15 @@ impl<S: SessionStorage> SessionManager for DefaultSessionManager<S> {
             .await
             .map_err(|e| StorageError::Database(e.to_string()))?;
 
-        if session.is_expired() {
-            self.delete_session(id).await?;
-            return Err(Error::Session(SessionError::Expired));
+        if let Some(session) = session {
+            if session.is_expired() {
+                self.delete_session(id).await?;
+                return Err(Error::Session(SessionError::Expired));
+            }
+            Ok(session)
+        } else {
+            Err(Error::Session(SessionError::NotFound))
         }
-
-        Ok(session)
     }
 
     async fn delete_session(&self, id: &SessionId) -> Result<(), Error> {

--- a/torii-core/src/session.rs
+++ b/torii-core/src/session.rs
@@ -73,7 +73,7 @@ impl std::fmt::Display for SessionId {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Session {
     /// The unique identifier for the session.
-    pub id: SessionId,
+    pub token: SessionId,
 
     /// The unique identifier for the user.
     pub user_id: UserId,
@@ -154,7 +154,7 @@ impl SessionBuilder {
     pub fn build(self) -> Result<Session, Error> {
         let now = Utc::now();
         Ok(Session {
-            id: self.id.unwrap_or(SessionId::new_random()),
+            token: self.id.unwrap_or(SessionId::new_random()),
             user_id: self.user_id.ok_or(ValidationError::MissingField(
                 "User ID is required".to_string(),
             ))?,
@@ -285,6 +285,6 @@ mod tests {
             .build()
             .unwrap();
 
-        assert_eq!(session.id.to_string(), session.id.0.to_string());
+        assert_eq!(session.token.to_string(), session.token.0.to_string());
     }
 }

--- a/torii-core/src/storage.rs
+++ b/torii-core/src/storage.rs
@@ -193,22 +193,27 @@ impl NewUserBuilder {
 /// storing and retrieving passkey credentials for a user.
 #[async_trait]
 pub trait PasskeyStorage: UserStorage {
+    type Error: std::error::Error + Send + Sync + 'static;
+
     /// Add a passkey credential for a user
     async fn add_passkey(
         &self,
         user_id: &UserId,
         credential_id: &str,
         passkey_json: &str,
-    ) -> Result<(), Self::Error>;
+    ) -> Result<(), <Self as PasskeyStorage>::Error>;
 
     /// Get a passkey by credential ID
     async fn get_passkey_by_credential_id(
         &self,
         credential_id: &str,
-    ) -> Result<Option<String>, Self::Error>;
+    ) -> Result<Option<String>, <Self as PasskeyStorage>::Error>;
 
     /// Get all passkeys for a user
-    async fn get_passkeys(&self, user_id: &UserId) -> Result<Vec<String>, Self::Error>;
+    async fn get_passkeys(
+        &self,
+        user_id: &UserId,
+    ) -> Result<Vec<String>, <Self as PasskeyStorage>::Error>;
 
     /// Set a passkey challenge for a user
     async fn set_passkey_challenge(
@@ -216,13 +221,13 @@ pub trait PasskeyStorage: UserStorage {
         challenge_id: &str,
         challenge: &str,
         expires_in: chrono::Duration,
-    ) -> Result<(), Self::Error>;
+    ) -> Result<(), <Self as PasskeyStorage>::Error>;
 
     /// Get a passkey challenge
     async fn get_passkey_challenge(
         &self,
         challenge_id: &str,
-    ) -> Result<Option<String>, Self::Error>;
+    ) -> Result<Option<String>, <Self as PasskeyStorage>::Error>;
 }
 
 #[derive(Debug, Clone)]

--- a/torii-core/src/storage.rs
+++ b/torii-core/src/storage.rs
@@ -50,11 +50,19 @@ pub trait SessionStorage: Send + Sync + 'static {
 /// storing and retrieving password hashes.
 #[async_trait]
 pub trait PasswordStorage: UserStorage {
+    type Error: std::error::Error + Send + Sync + 'static;
     /// Store a password hash for a user
-    async fn set_password_hash(&self, user_id: &UserId, hash: &str) -> Result<(), Self::Error>;
+    async fn set_password_hash(
+        &self,
+        user_id: &UserId,
+        hash: &str,
+    ) -> Result<(), <Self as PasswordStorage>::Error>;
 
     /// Retrieve a user's password hash
-    async fn get_password_hash(&self, user_id: &UserId) -> Result<Option<String>, Self::Error>;
+    async fn get_password_hash(
+        &self,
+        user_id: &UserId,
+    ) -> Result<Option<String>, <Self as PasswordStorage>::Error>;
 }
 
 /// Storage methods specific to OAuth authentication

--- a/torii-core/src/storage.rs
+++ b/torii-core/src/storage.rs
@@ -71,27 +71,28 @@ pub trait PasswordStorage: UserStorage {
 /// OAuth account management and PKCE verifier storage.
 #[async_trait]
 pub trait OAuthStorage: UserStorage {
+    type Error: std::error::Error + Send + Sync + 'static;
     /// Create a new OAuth account linked to a user
     async fn create_oauth_account(
         &self,
         provider: &str,
         subject: &str,
         user_id: &UserId,
-    ) -> Result<OAuthAccount, Self::Error>;
+    ) -> Result<OAuthAccount, <Self as OAuthStorage>::Error>;
 
     /// Find a user by their OAuth provider and subject
     async fn get_user_by_provider_and_subject(
         &self,
         provider: &str,
         subject: &str,
-    ) -> Result<Option<User>, Self::Error>;
+    ) -> Result<Option<User>, <Self as OAuthStorage>::Error>;
 
     /// Find an OAuth account by provider and subject
     async fn get_oauth_account_by_provider_and_subject(
         &self,
         provider: &str,
         subject: &str,
-    ) -> Result<Option<OAuthAccount>, Self::Error>;
+    ) -> Result<Option<OAuthAccount>, <Self as OAuthStorage>::Error>;
 
     /// Link an existing user to an OAuth account
     async fn link_oauth_account(
@@ -99,7 +100,7 @@ pub trait OAuthStorage: UserStorage {
         user_id: &UserId,
         provider: &str,
         subject: &str,
-    ) -> Result<(), Self::Error>;
+    ) -> Result<(), <Self as OAuthStorage>::Error>;
 
     /// Store a PKCE verifier with an expiration time
     async fn store_pkce_verifier(
@@ -107,10 +108,13 @@ pub trait OAuthStorage: UserStorage {
         csrf_state: &str,
         pkce_verifier: &str,
         expires_in: chrono::Duration,
-    ) -> Result<(), Self::Error>;
+    ) -> Result<(), <Self as OAuthStorage>::Error>;
 
     /// Retrieve a stored PKCE verifier by CSRF state
-    async fn get_pkce_verifier(&self, csrf_state: &str) -> Result<Option<String>, Self::Error>;
+    async fn get_pkce_verifier(
+        &self,
+        csrf_state: &str,
+    ) -> Result<Option<String>, <Self as OAuthStorage>::Error>;
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/torii-core/src/storage.rs
+++ b/torii-core/src/storage.rs
@@ -278,7 +278,18 @@ impl PartialEq for MagicToken {
 
 #[async_trait]
 pub trait MagicLinkStorage: UserStorage {
-    async fn save_magic_token(&self, token: &MagicToken) -> Result<(), Self::Error>;
-    async fn get_magic_token(&self, token: &str) -> Result<Option<MagicToken>, Self::Error>;
-    async fn set_magic_token_used(&self, token: &str) -> Result<(), Self::Error>;
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    async fn save_magic_token(
+        &self,
+        token: &MagicToken,
+    ) -> Result<(), <Self as MagicLinkStorage>::Error>;
+    async fn get_magic_token(
+        &self,
+        token: &str,
+    ) -> Result<Option<MagicToken>, <Self as MagicLinkStorage>::Error>;
+    async fn set_magic_token_used(
+        &self,
+        token: &str,
+    ) -> Result<(), <Self as MagicLinkStorage>::Error>;
 }

--- a/torii-core/src/storage.rs
+++ b/torii-core/src/storage.rs
@@ -38,7 +38,7 @@ pub trait SessionStorage: Send + Sync + 'static {
     type Error: std::error::Error + Send + Sync + 'static;
 
     async fn create_session(&self, session: &Session) -> Result<Session, Self::Error>;
-    async fn get_session(&self, id: &SessionId) -> Result<Session, Self::Error>;
+    async fn get_session(&self, id: &SessionId) -> Result<Option<Session>, Self::Error>;
     async fn delete_session(&self, id: &SessionId) -> Result<(), Self::Error>;
     async fn cleanup_expired_sessions(&self) -> Result<(), Self::Error>;
     async fn delete_sessions_for_user(&self, user_id: &UserId) -> Result<(), Self::Error>;

--- a/torii-storage-postgres/src/passkey.rs
+++ b/torii-storage-postgres/src/passkey.rs
@@ -7,12 +7,14 @@ use torii_core::storage::PasskeyStorage;
 
 #[async_trait]
 impl PasskeyStorage for PostgresStorage {
+    type Error = StorageError;
+
     async fn add_passkey(
         &self,
         user_id: &UserId,
         credential_id: &str,
         passkey_json: &str,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), <Self as PasskeyStorage>::Error> {
         sqlx::query(
             r#"
             INSERT INTO passkeys (credential_id, user_id, public_key) 
@@ -31,7 +33,7 @@ impl PasskeyStorage for PostgresStorage {
     async fn get_passkey_by_credential_id(
         &self,
         credential_id: &str,
-    ) -> Result<Option<String>, Self::Error> {
+    ) -> Result<Option<String>, <Self as PasskeyStorage>::Error> {
         let passkey: Option<String> = sqlx::query_scalar(
             r#"
             SELECT public_key 
@@ -46,7 +48,10 @@ impl PasskeyStorage for PostgresStorage {
         Ok(passkey)
     }
 
-    async fn get_passkeys(&self, user_id: &UserId) -> Result<Vec<String>, Self::Error> {
+    async fn get_passkeys(
+        &self,
+        user_id: &UserId,
+    ) -> Result<Vec<String>, <Self as PasskeyStorage>::Error> {
         let passkeys: Vec<String> = sqlx::query_scalar(
             r#"
             SELECT public_key 
@@ -66,7 +71,7 @@ impl PasskeyStorage for PostgresStorage {
         challenge_id: &str,
         challenge: &str,
         expires_in: chrono::Duration,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), <Self as PasskeyStorage>::Error> {
         sqlx::query(
             r#"
             INSERT INTO passkey_challenges (id, challenge, expires_at) 
@@ -85,7 +90,7 @@ impl PasskeyStorage for PostgresStorage {
     async fn get_passkey_challenge(
         &self,
         challenge_id: &str,
-    ) -> Result<Option<String>, Self::Error> {
+    ) -> Result<Option<String>, <Self as PasskeyStorage>::Error> {
         let challenge: Option<String> = sqlx::query_scalar(
             r#"
             SELECT challenge 

--- a/torii-storage-postgres/src/password.rs
+++ b/torii-storage-postgres/src/password.rs
@@ -6,11 +6,13 @@ use torii_core::storage::PasswordStorage;
 
 #[async_trait]
 impl PasswordStorage for PostgresStorage {
+    type Error = StorageError;
+
     async fn set_password_hash(
         &self,
         user_id: &UserId,
         hash: &str,
-    ) -> Result<(), torii_core::Error> {
+    ) -> Result<(), <Self as PasswordStorage>::Error> {
         sqlx::query("UPDATE users SET password_hash = $1 WHERE id::text = $2")
             .bind(hash)
             .bind(user_id.as_str())
@@ -23,7 +25,7 @@ impl PasswordStorage for PostgresStorage {
     async fn get_password_hash(
         &self,
         user_id: &UserId,
-    ) -> Result<Option<String>, torii_core::Error> {
+    ) -> Result<Option<String>, <Self as PasswordStorage>::Error> {
         let result = sqlx::query_scalar("SELECT password_hash FROM users WHERE id::text = $1")
             .bind(user_id.as_str())
             .fetch_optional(&self.pool)

--- a/torii-storage-seaorm/Cargo.toml
+++ b/torii-storage-seaorm/Cargo.toml
@@ -18,6 +18,7 @@ sea-orm = { version = "1.1", features = [
     "with-uuid",
 ] }
 sea-orm-migration = { version = "1.1", features = ["runtime-tokio-rustls"] }
+thiserror.workspace = true
 
 [dev-dependencies]
 tokio.workspace = true

--- a/torii-storage-seaorm/Cargo.toml
+++ b/torii-storage-seaorm/Cargo.toml
@@ -19,6 +19,7 @@ sea-orm = { version = "1.1", features = [
 ] }
 sea-orm-migration = { version = "1.1", features = ["runtime-tokio-rustls"] }
 thiserror.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 tokio.workspace = true

--- a/torii-storage-seaorm/Cargo.toml
+++ b/torii-storage-seaorm/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "torii-storage-seaorm"
+description = "SeaORM storage plugin for Torii"
+version = "0.2.3"
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+torii-core = { path = "../torii-core", version = "0.2" }
+
+async-trait.workspace = true
+chrono.workspace = true
+sea-orm = { version = "1.1", features = [
+    "runtime-tokio-rustls",
+    "macros",
+    "with-chrono",
+    "with-uuid",
+] }
+sea-orm-migration = { version = "1.1", features = ["runtime-tokio-rustls"] }
+
+[dev-dependencies]
+tokio.workspace = true
+[features]
+default = ["sqlite"]
+sqlite = ["sea-orm/sqlx-sqlite", "sea-orm-migration/sqlx-sqlite"]
+postgres = ["sea-orm/sqlx-postgres", "sea-orm-migration/sqlx-postgres"]
+mysql = ["sea-orm/sqlx-mysql", "sea-orm-migration/sqlx-mysql"]

--- a/torii-storage-seaorm/src/entities/magic_link.rs
+++ b/torii-storage-seaorm/src/entities/magic_link.rs
@@ -4,8 +4,8 @@ use sea_orm::entity::prelude::*;
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "magic_links")]
 pub struct Model {
-    #[sea_orm(primary_key, auto_increment = false)]
-    pub id: String,
+    #[sea_orm(primary_key)]
+    pub id: i64,
     pub user_id: String,
     pub token: String,
     pub used_at: Option<DateTime<Utc>>,

--- a/torii-storage-seaorm/src/entities/magic_link.rs
+++ b/torii-storage-seaorm/src/entities/magic_link.rs
@@ -1,0 +1,20 @@
+use chrono::{DateTime, Utc};
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "magic_links")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub user_id: String,
+    pub token: String,
+    pub used_at: Option<DateTime<Utc>>,
+    pub expires_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/torii-storage-seaorm/src/entities/mod.rs
+++ b/torii-storage-seaorm/src/entities/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod session;
+pub(crate) mod user;

--- a/torii-storage-seaorm/src/entities/mod.rs
+++ b/torii-storage-seaorm/src/entities/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod magic_link;
 pub(crate) mod oauth;
 pub(crate) mod passkey;
 pub(crate) mod passkey_challenge;

--- a/torii-storage-seaorm/src/entities/mod.rs
+++ b/torii-storage-seaorm/src/entities/mod.rs
@@ -1,4 +1,6 @@
 pub(crate) mod oauth;
+pub(crate) mod passkey;
+pub(crate) mod passkey_challenge;
 pub(crate) mod pkce_verifier;
 pub(crate) mod session;
 pub(crate) mod user;

--- a/torii-storage-seaorm/src/entities/mod.rs
+++ b/torii-storage-seaorm/src/entities/mod.rs
@@ -1,2 +1,4 @@
+pub(crate) mod oauth;
+pub(crate) mod pkce_verifier;
 pub(crate) mod session;
 pub(crate) mod user;

--- a/torii-storage-seaorm/src/entities/oauth.rs
+++ b/torii-storage-seaorm/src/entities/oauth.rs
@@ -1,0 +1,19 @@
+use chrono::{DateTime, Utc};
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "oauth_accounts")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub user_id: String,
+    pub provider: String,
+    pub subject: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/torii-storage-seaorm/src/entities/oauth.rs
+++ b/torii-storage-seaorm/src/entities/oauth.rs
@@ -4,8 +4,8 @@ use sea_orm::entity::prelude::*;
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "oauth_accounts")]
 pub struct Model {
-    #[sea_orm(primary_key, auto_increment = false)]
-    pub id: String,
+    #[sea_orm(primary_key)]
+    pub id: i64,
     pub user_id: String,
     pub provider: String,
     pub subject: String,

--- a/torii-storage-seaorm/src/entities/passkey.rs
+++ b/torii-storage-seaorm/src/entities/passkey.rs
@@ -1,0 +1,19 @@
+use chrono::{DateTime, Utc};
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "passkeys")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub user_id: String,
+    pub credential_id: String,
+    pub data_json: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/torii-storage-seaorm/src/entities/passkey.rs
+++ b/torii-storage-seaorm/src/entities/passkey.rs
@@ -4,8 +4,8 @@ use sea_orm::entity::prelude::*;
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "passkeys")]
 pub struct Model {
-    #[sea_orm(primary_key, auto_increment = false)]
-    pub id: String,
+    #[sea_orm(primary_key)]
+    pub id: i64,
     pub user_id: String,
     pub credential_id: String,
     pub data_json: String,

--- a/torii-storage-seaorm/src/entities/passkey_challenge.rs
+++ b/torii-storage-seaorm/src/entities/passkey_challenge.rs
@@ -1,0 +1,19 @@
+use chrono::{DateTime, Utc};
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "passkey_challenges")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub challenge_id: String,
+    pub challenge: String,
+    pub expires_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/torii-storage-seaorm/src/entities/passkey_challenge.rs
+++ b/torii-storage-seaorm/src/entities/passkey_challenge.rs
@@ -4,8 +4,8 @@ use sea_orm::entity::prelude::*;
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "passkey_challenges")]
 pub struct Model {
-    #[sea_orm(primary_key, auto_increment = false)]
-    pub id: String,
+    #[sea_orm(primary_key)]
+    pub id: i64,
     pub challenge_id: String,
     pub challenge: String,
     pub expires_at: DateTime<Utc>,

--- a/torii-storage-seaorm/src/entities/pkce_verifier.rs
+++ b/torii-storage-seaorm/src/entities/pkce_verifier.rs
@@ -1,0 +1,19 @@
+use chrono::{DateTime, Utc};
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "pkce_verifiers")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub csrf_state: String,
+    pub verifier: String,
+    pub expires_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/torii-storage-seaorm/src/entities/pkce_verifier.rs
+++ b/torii-storage-seaorm/src/entities/pkce_verifier.rs
@@ -4,8 +4,8 @@ use sea_orm::entity::prelude::*;
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "pkce_verifiers")]
 pub struct Model {
-    #[sea_orm(primary_key, auto_increment = false)]
-    pub id: String,
+    #[sea_orm(primary_key)]
+    pub id: i64,
     pub csrf_state: String,
     pub verifier: String,
     pub expires_at: DateTime<Utc>,

--- a/torii-storage-seaorm/src/entities/session.rs
+++ b/torii-storage-seaorm/src/entities/session.rs
@@ -4,8 +4,8 @@ use sea_orm::entity::prelude::*;
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "sessions")]
 pub struct Model {
-    #[sea_orm(primary_key, auto_increment = false)]
-    pub id: String,
+    #[sea_orm(primary_key)]
+    pub id: i64,
     pub user_id: String,
     pub token: String,
     pub ip_address: Option<String>,

--- a/torii-storage-seaorm/src/entities/session.rs
+++ b/torii-storage-seaorm/src/entities/session.rs
@@ -1,0 +1,21 @@
+use chrono::{DateTime, Utc};
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "sessions")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub user_id: String,
+    pub token: String,
+    pub ip_address: Option<String>,
+    pub user_agent: Option<String>,
+    pub expires_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/torii-storage-seaorm/src/entities/user.rs
+++ b/torii-storage-seaorm/src/entities/user.rs
@@ -9,6 +9,7 @@ pub struct Model {
     pub email: String,
     pub name: Option<String>,
     pub email_verified_at: Option<DateTime<Utc>>,
+    pub password_hash: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }

--- a/torii-storage-seaorm/src/entities/user.rs
+++ b/torii-storage-seaorm/src/entities/user.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use sea_orm::entity::prelude::*;
+use sea_orm::{ActiveValue::Set, entity::prelude::*};
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "users")]
@@ -17,4 +17,11 @@ pub struct Model {
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {}
 
-impl ActiveModelBehavior for ActiveModel {}
+impl ActiveModelBehavior for ActiveModel {
+    fn new() -> Self {
+        Self {
+            id: Set(Uuid::new_v4().to_string()),
+            ..ActiveModelTrait::default()
+        }
+    }
+}

--- a/torii-storage-seaorm/src/entities/user.rs
+++ b/torii-storage-seaorm/src/entities/user.rs
@@ -1,0 +1,19 @@
+use chrono::{DateTime, Utc};
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "users")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub email: String,
+    pub name: Option<String>,
+    pub email_verified_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/torii-storage-seaorm/src/lib.rs
+++ b/torii-storage-seaorm/src/lib.rs
@@ -1,10 +1,19 @@
 mod entities;
 mod migrations;
+mod password;
 mod session;
 mod user;
 
 use sea_orm::DatabaseConnection;
 use sea_orm_migration::prelude::*;
+
+#[derive(Debug, thiserror::Error)]
+pub enum SeaORMStorageError {
+    #[error(transparent)]
+    Database(#[from] sea_orm::DbErr),
+    #[error("User not found")]
+    UserNotFound,
+}
 
 pub struct SeaORMStorage {
     pool: DatabaseConnection,

--- a/torii-storage-seaorm/src/lib.rs
+++ b/torii-storage-seaorm/src/lib.rs
@@ -1,4 +1,5 @@
 mod entities;
+mod magic_link;
 mod migrations;
 mod oauth;
 mod passkey;

--- a/torii-storage-seaorm/src/lib.rs
+++ b/torii-storage-seaorm/src/lib.rs
@@ -1,5 +1,6 @@
 mod entities;
 mod migrations;
+mod oauth;
 mod password;
 mod session;
 mod user;

--- a/torii-storage-seaorm/src/lib.rs
+++ b/torii-storage-seaorm/src/lib.rs
@@ -1,6 +1,7 @@
 mod entities;
 mod migrations;
 mod oauth;
+mod passkey;
 mod password;
 mod session;
 mod user;

--- a/torii-storage-seaorm/src/lib.rs
+++ b/torii-storage-seaorm/src/lib.rs
@@ -43,14 +43,13 @@ impl SeaORMStorage {
     }
 
     pub async fn connect(url: &str) -> Result<Self, SeaORMStorageError> {
-        let pool = Database::connect(url)
-            .await
-            .map_err(|e| SeaORMStorageError::Database(e))?;
+        let pool = Database::connect(url).await?;
+
         Ok(Self::new(pool))
     }
 
     pub async fn migrate(&self) -> Result<(), SeaORMStorageError> {
-        let _ = Migrator::up(&self.pool, None).await.unwrap();
+        Migrator::up(&self.pool, None).await.unwrap();
 
         Ok(())
     }

--- a/torii-storage-seaorm/src/lib.rs
+++ b/torii-storage-seaorm/src/lib.rs
@@ -1,0 +1,40 @@
+mod entities;
+mod migrations;
+mod session;
+mod user;
+
+use sea_orm::DatabaseConnection;
+use sea_orm_migration::prelude::*;
+
+pub struct SeaORMStorage {
+    pool: DatabaseConnection,
+}
+
+impl SeaORMStorage {
+    pub fn new(pool: DatabaseConnection) -> Self {
+        Self { pool }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::Database;
+
+    use crate::migrations::Migrator;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_migrations_up() {
+        let pool = Database::connect("sqlite::memory:").await.unwrap();
+        let migrations = Migrator::get_pending_migrations(&pool).await.unwrap();
+        migrations.iter().for_each(|m| {
+            println!("{}: {}", m.name(), m.status());
+        });
+        let _ = Migrator::up(&pool, None).await.unwrap();
+        let migrations = Migrator::get_pending_migrations(&pool).await.unwrap();
+        migrations.iter().for_each(|m| {
+            println!("{}: {}", m.name(), m.status());
+        });
+    }
+}

--- a/torii-storage-seaorm/src/magic_link.rs
+++ b/torii-storage-seaorm/src/magic_link.rs
@@ -34,13 +34,11 @@ impl MagicLinkStorage for SeaORMStorage {
         token: &MagicToken,
     ) -> Result<(), <Self as MagicLinkStorage>::Error> {
         let magic_link = magic_link::ActiveModel {
-            id: Set(Uuid::new_v4().to_string()),
             user_id: Set(token.user_id.to_string()),
             token: Set(token.token.clone()),
             used_at: Set(token.used_at),
             expires_at: Set(token.expires_at),
-            created_at: Set(Utc::now()),
-            updated_at: Set(Utc::now()),
+            ..Default::default()
         };
         magic_link.insert(&self.pool).await?;
 

--- a/torii-storage-seaorm/src/magic_link.rs
+++ b/torii-storage-seaorm/src/magic_link.rs
@@ -1,0 +1,79 @@
+use async_trait::async_trait;
+use chrono::Utc;
+use sea_orm::{
+    ActiveModelTrait, ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter, prelude::Uuid,
+};
+use torii_core::{
+    UserId,
+    storage::{MagicLinkStorage, MagicToken},
+};
+
+use crate::entities::magic_link;
+
+use crate::{SeaORMStorage, SeaORMStorageError};
+
+impl From<magic_link::Model> for MagicToken {
+    fn from(value: magic_link::Model) -> Self {
+        MagicToken {
+            user_id: UserId::new(&value.user_id),
+            token: value.token,
+            used_at: value.used_at,
+            expires_at: value.expires_at,
+            created_at: value.created_at,
+            updated_at: value.updated_at,
+        }
+    }
+}
+
+#[async_trait]
+impl MagicLinkStorage for SeaORMStorage {
+    type Error = SeaORMStorageError;
+
+    async fn save_magic_token(
+        &self,
+        token: &MagicToken,
+    ) -> Result<(), <Self as MagicLinkStorage>::Error> {
+        let magic_link = magic_link::ActiveModel {
+            id: Set(Uuid::new_v4().to_string()),
+            user_id: Set(token.user_id.to_string()),
+            token: Set(token.token.clone()),
+            used_at: Set(token.used_at),
+            expires_at: Set(token.expires_at),
+            created_at: Set(Utc::now()),
+            updated_at: Set(Utc::now()),
+        };
+        magic_link.insert(&self.pool).await?;
+
+        Ok(())
+    }
+
+    async fn get_magic_token(
+        &self,
+        token: &str,
+    ) -> Result<Option<MagicToken>, <Self as MagicLinkStorage>::Error> {
+        let magic_link = magic_link::Entity::find()
+            .filter(magic_link::Column::Token.eq(token))
+            .one(&self.pool)
+            .await?;
+
+        Ok(magic_link.map(|model| model.into()))
+    }
+
+    async fn set_magic_token_used(
+        &self,
+        token: &str,
+    ) -> Result<(), <Self as MagicLinkStorage>::Error> {
+        let magic_link: Option<magic_link::ActiveModel> = magic_link::Entity::find()
+            .filter(magic_link::Column::Token.eq(token))
+            .one(&self.pool)
+            .await?
+            .map(|model| model.into());
+
+        if let Some(mut magic_link) = magic_link {
+            magic_link.used_at = Set(Some(Utc::now()));
+            magic_link.update(&self.pool).await?;
+        }
+
+        Ok(())
+    }
+}

--- a/torii-storage-seaorm/src/magic_link.rs
+++ b/torii-storage-seaorm/src/magic_link.rs
@@ -1,8 +1,6 @@
 use async_trait::async_trait;
 use chrono::Utc;
-use sea_orm::{
-    ActiveModelTrait, ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter, prelude::Uuid,
-};
+use sea_orm::{ActiveModelTrait, ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter};
 use torii_core::{
     UserId,
     storage::{MagicLinkStorage, MagicToken},

--- a/torii-storage-seaorm/src/migrations/m20250304_000001_create_user_table.rs
+++ b/torii-storage-seaorm/src/migrations/m20250304_000001_create_user_table.rs
@@ -17,21 +17,13 @@ impl MigrationTrait for CreateUsers {
                 Table::create()
                     .table(Users::Table)
                     .if_not_exists()
-                    .col(pk_uuid(Users::Id).not_null())
-                    .col(string(Users::Email).not_null())
+                    .col(pk_uuid(Users::Id))
+                    .col(string(Users::Email))
                     .col(string_null(Users::Name)) // Nullable since users may not have a name yet...
                     .col(string_null(Users::PasswordHash)) // Nullable since users may not have a password (i.e. OAuth, Passkey, Magic Link)
                     .col(timestamp_null(Users::EmailVerifiedAt))
-                    .col(
-                        timestamp(Users::CreatedAt)
-                            .not_null()
-                            .default(Expr::current_timestamp()),
-                    )
-                    .col(
-                        timestamp(Users::UpdatedAt)
-                            .not_null()
-                            .default(Expr::current_timestamp()),
-                    )
+                    .col(timestamp(Users::CreatedAt).default(Expr::current_timestamp()))
+                    .col(timestamp(Users::UpdatedAt).default(Expr::current_timestamp()))
                     .to_owned(),
             )
             .await?;

--- a/torii-storage-seaorm/src/migrations/m20250304_000001_create_user_table.rs
+++ b/torii-storage-seaorm/src/migrations/m20250304_000001_create_user_table.rs
@@ -1,7 +1,7 @@
 use sea_orm::{DbErr, DeriveMigrationName, prelude::*, sea_query::Table};
 use sea_orm_migration::{
     MigrationTrait, SchemaManager,
-    schema::{pk_uuid, string, timestamp},
+    schema::{pk_uuid, string, string_null, timestamp, timestamp_null},
 };
 
 use super::Users;
@@ -19,8 +19,9 @@ impl MigrationTrait for CreateUsers {
                     .if_not_exists()
                     .col(pk_uuid(Users::Id).not_null())
                     .col(string(Users::Email).not_null())
-                    .col(string(Users::Name).not_null())
-                    .col(timestamp(Users::EmailVerifiedAt).timestamp())
+                    .col(string_null(Users::Name)) // Nullable since users may not have a name yet...
+                    .col(string_null(Users::PasswordHash)) // Nullable since users may not have a password (i.e. OAuth, Passkey, Magic Link)
+                    .col(timestamp_null(Users::EmailVerifiedAt))
                     .col(
                         timestamp(Users::CreatedAt)
                             .not_null()

--- a/torii-storage-seaorm/src/migrations/m20250304_000001_create_user_table.rs
+++ b/torii-storage-seaorm/src/migrations/m20250304_000001_create_user_table.rs
@@ -1,4 +1,8 @@
-use sea_orm::{DbErr, DeriveMigrationName, prelude::*, sea_query::Table};
+use sea_orm::{
+    DbErr, DeriveMigrationName,
+    prelude::*,
+    sea_query::{Index, Table},
+};
 use sea_orm_migration::{
     MigrationTrait, SchemaManager,
     schema::{pk_uuid, string, string_null, timestamp, timestamp_null},
@@ -24,6 +28,17 @@ impl MigrationTrait for CreateUsers {
                     .col(timestamp_null(Users::EmailVerifiedAt))
                     .col(timestamp(Users::CreatedAt).default(Expr::current_timestamp()))
                     .col(timestamp(Users::UpdatedAt).default(Expr::current_timestamp()))
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(Users::Table)
+                    .name("idx_users_email")
+                    .col(Users::Email)
+                    .unique()
                     .to_owned(),
             )
             .await?;

--- a/torii-storage-seaorm/src/migrations/m20250304_000001_create_user_table.rs
+++ b/torii-storage-seaorm/src/migrations/m20250304_000001_create_user_table.rs
@@ -1,0 +1,39 @@
+use sea_orm::{DbErr, DeriveMigrationName, prelude::*, sea_query::Table};
+use sea_orm_migration::{
+    MigrationTrait, SchemaManager,
+    schema::{pk_uuid, string, timestamp},
+};
+
+use super::Users;
+
+#[derive(DeriveMigrationName)]
+pub struct CreateUsers;
+
+#[async_trait::async_trait]
+impl MigrationTrait for CreateUsers {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(Users::Table)
+                    .if_not_exists()
+                    .col(pk_uuid(Users::Id).not_null())
+                    .col(string(Users::Email).not_null())
+                    .col(string(Users::Name).not_null())
+                    .col(timestamp(Users::EmailVerifiedAt).timestamp())
+                    .col(
+                        timestamp(Users::CreatedAt)
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .col(
+                        timestamp(Users::UpdatedAt)
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+}

--- a/torii-storage-seaorm/src/migrations/m20250304_000002_create_session_table.rs
+++ b/torii-storage-seaorm/src/migrations/m20250304_000002_create_session_table.rs
@@ -1,4 +1,8 @@
-use sea_orm::{DbErr, DeriveMigrationName, prelude::*, sea_query::Table};
+use sea_orm::{
+    DbErr, DeriveMigrationName,
+    prelude::*,
+    sea_query::{Index, Table},
+};
 use sea_orm_migration::{
     MigrationTrait, SchemaManager,
     schema::{pk_auto, string, string_null, timestamp},
@@ -28,6 +32,58 @@ impl MigrationTrait for CreateSessions {
                     .to_owned(),
             )
             .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(Sessions::Table)
+                    .name("idx_sessions_token")
+                    .col(Sessions::Token)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(Sessions::Table)
+                    .name("idx_sessions_user_id")
+                    .col(Sessions::UserId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(Sessions::Table)
+                    .name("idx_sessions_expires_at")
+                    .col(Sessions::ExpiresAt)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(Sessions::Table)
+                    .name("idx_sessions_created_at")
+                    .col(Sessions::CreatedAt)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(Sessions::Table)
+                    .name("idx_sessions_updated_at")
+                    .col(Sessions::UpdatedAt)
+                    .to_owned(),
+            )
+            .await?;
+
         Ok(())
     }
 }

--- a/torii-storage-seaorm/src/migrations/m20250304_000002_create_session_table.rs
+++ b/torii-storage-seaorm/src/migrations/m20250304_000002_create_session_table.rs
@@ -1,0 +1,41 @@
+use sea_orm::{DbErr, DeriveMigrationName, prelude::*, sea_query::Table};
+use sea_orm_migration::{
+    MigrationTrait, SchemaManager,
+    schema::{pk_uuid, string, timestamp},
+};
+
+use super::Sessions;
+
+#[derive(DeriveMigrationName)]
+pub struct CreateSessions;
+
+#[async_trait::async_trait]
+impl MigrationTrait for CreateSessions {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(Sessions::Table)
+                    .if_not_exists()
+                    .col(pk_uuid(Sessions::Id).not_null())
+                    .col(string(Sessions::UserId).not_null())
+                    .col(string(Sessions::Token).not_null())
+                    .col(string(Sessions::IpAddress))
+                    .col(string(Sessions::UserAgent))
+                    .col(timestamp(Sessions::ExpiresAt).timestamp())
+                    .col(
+                        timestamp(Sessions::CreatedAt)
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .col(
+                        timestamp(Sessions::UpdatedAt)
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+}

--- a/torii-storage-seaorm/src/migrations/m20250304_000002_create_session_table.rs
+++ b/torii-storage-seaorm/src/migrations/m20250304_000002_create_session_table.rs
@@ -1,7 +1,7 @@
 use sea_orm::{DbErr, DeriveMigrationName, prelude::*, sea_query::Table};
 use sea_orm_migration::{
     MigrationTrait, SchemaManager,
-    schema::{pk_uuid, string, timestamp},
+    schema::{pk_auto, string, string_null, timestamp},
 };
 
 use super::Sessions;
@@ -17,22 +17,14 @@ impl MigrationTrait for CreateSessions {
                 Table::create()
                     .table(Sessions::Table)
                     .if_not_exists()
-                    .col(pk_uuid(Sessions::Id).not_null())
-                    .col(string(Sessions::UserId).not_null())
-                    .col(string(Sessions::Token).not_null())
-                    .col(string(Sessions::IpAddress))
-                    .col(string(Sessions::UserAgent))
-                    .col(timestamp(Sessions::ExpiresAt).timestamp())
-                    .col(
-                        timestamp(Sessions::CreatedAt)
-                            .not_null()
-                            .default(Expr::current_timestamp()),
-                    )
-                    .col(
-                        timestamp(Sessions::UpdatedAt)
-                            .not_null()
-                            .default(Expr::current_timestamp()),
-                    )
+                    .col(pk_auto(Sessions::Id))
+                    .col(string(Sessions::UserId))
+                    .col(string(Sessions::Token))
+                    .col(string_null(Sessions::IpAddress))
+                    .col(string_null(Sessions::UserAgent))
+                    .col(timestamp(Sessions::ExpiresAt))
+                    .col(timestamp(Sessions::CreatedAt).default(Expr::current_timestamp()))
+                    .col(timestamp(Sessions::UpdatedAt).default(Expr::current_timestamp()))
                     .to_owned(),
             )
             .await?;

--- a/torii-storage-seaorm/src/migrations/m20250304_000003_create_oauth_table.rs
+++ b/torii-storage-seaorm/src/migrations/m20250304_000003_create_oauth_table.rs
@@ -1,0 +1,69 @@
+use sea_orm::{DbErr, DeriveMigrationName, prelude::*, sea_query::Table};
+use sea_orm_migration::{
+    MigrationTrait, SchemaManager,
+    schema::{pk_uuid, string, timestamp},
+};
+
+use super::OauthAccounts;
+use super::PkceVerifiers;
+#[derive(DeriveMigrationName)]
+pub struct CreateOAuthAccounts;
+
+#[async_trait::async_trait]
+impl MigrationTrait for CreateOAuthAccounts {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(OauthAccounts::Table)
+                    .if_not_exists()
+                    .col(pk_uuid(OauthAccounts::Id).not_null())
+                    .col(string(OauthAccounts::UserId).not_null())
+                    .col(string(OauthAccounts::Provider).not_null())
+                    .col(string(OauthAccounts::Subject).not_null())
+                    .col(
+                        timestamp(OauthAccounts::CreatedAt)
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .col(
+                        timestamp(OauthAccounts::UpdatedAt)
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(PkceVerifiers::Table)
+                    .if_not_exists()
+                    .col(pk_uuid(PkceVerifiers::Id).not_null())
+                    .col(string(PkceVerifiers::CsrfState).not_null())
+                    .col(string(PkceVerifiers::Verifier).not_null())
+                    .col(
+                        timestamp(PkceVerifiers::ExpiresAt)
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .col(
+                        timestamp(PkceVerifiers::CreatedAt)
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .col(
+                        timestamp(PkceVerifiers::UpdatedAt)
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // TODO: Add indexes
+
+        Ok(())
+    }
+}

--- a/torii-storage-seaorm/src/migrations/m20250304_000003_create_oauth_table.rs
+++ b/torii-storage-seaorm/src/migrations/m20250304_000003_create_oauth_table.rs
@@ -1,7 +1,7 @@
 use sea_orm::{DbErr, DeriveMigrationName, prelude::*, sea_query::Table};
 use sea_orm_migration::{
     MigrationTrait, SchemaManager,
-    schema::{pk_uuid, string, timestamp},
+    schema::{pk_auto, string, timestamp},
 };
 
 use super::OauthAccounts;
@@ -17,20 +17,12 @@ impl MigrationTrait for CreateOAuthAccounts {
                 Table::create()
                     .table(OauthAccounts::Table)
                     .if_not_exists()
-                    .col(pk_uuid(OauthAccounts::Id).not_null())
-                    .col(string(OauthAccounts::UserId).not_null())
-                    .col(string(OauthAccounts::Provider).not_null())
-                    .col(string(OauthAccounts::Subject).not_null())
-                    .col(
-                        timestamp(OauthAccounts::CreatedAt)
-                            .not_null()
-                            .default(Expr::current_timestamp()),
-                    )
-                    .col(
-                        timestamp(OauthAccounts::UpdatedAt)
-                            .not_null()
-                            .default(Expr::current_timestamp()),
-                    )
+                    .col(pk_auto(OauthAccounts::Id))
+                    .col(string(OauthAccounts::UserId))
+                    .col(string(OauthAccounts::Provider))
+                    .col(string(OauthAccounts::Subject))
+                    .col(timestamp(OauthAccounts::CreatedAt).default(Expr::current_timestamp()))
+                    .col(timestamp(OauthAccounts::UpdatedAt).default(Expr::current_timestamp()))
                     .to_owned(),
             )
             .await?;
@@ -40,24 +32,12 @@ impl MigrationTrait for CreateOAuthAccounts {
                 Table::create()
                     .table(PkceVerifiers::Table)
                     .if_not_exists()
-                    .col(pk_uuid(PkceVerifiers::Id).not_null())
-                    .col(string(PkceVerifiers::CsrfState).not_null())
-                    .col(string(PkceVerifiers::Verifier).not_null())
-                    .col(
-                        timestamp(PkceVerifiers::ExpiresAt)
-                            .not_null()
-                            .default(Expr::current_timestamp()),
-                    )
-                    .col(
-                        timestamp(PkceVerifiers::CreatedAt)
-                            .not_null()
-                            .default(Expr::current_timestamp()),
-                    )
-                    .col(
-                        timestamp(PkceVerifiers::UpdatedAt)
-                            .not_null()
-                            .default(Expr::current_timestamp()),
-                    )
+                    .col(pk_auto(PkceVerifiers::Id))
+                    .col(string(PkceVerifiers::CsrfState))
+                    .col(string(PkceVerifiers::Verifier))
+                    .col(timestamp(PkceVerifiers::ExpiresAt).default(Expr::current_timestamp()))
+                    .col(timestamp(PkceVerifiers::CreatedAt).default(Expr::current_timestamp()))
+                    .col(timestamp(PkceVerifiers::UpdatedAt).default(Expr::current_timestamp()))
                     .to_owned(),
             )
             .await?;

--- a/torii-storage-seaorm/src/migrations/m20250304_000003_create_oauth_table.rs
+++ b/torii-storage-seaorm/src/migrations/m20250304_000003_create_oauth_table.rs
@@ -1,4 +1,8 @@
-use sea_orm::{DbErr, DeriveMigrationName, prelude::*, sea_query::Table};
+use sea_orm::{
+    DbErr, DeriveMigrationName,
+    prelude::*,
+    sea_query::{Index, Table},
+};
 use sea_orm_migration::{
     MigrationTrait, SchemaManager,
     schema::{pk_auto, string, timestamp},
@@ -28,6 +32,36 @@ impl MigrationTrait for CreateOAuthAccounts {
             .await?;
 
         manager
+            .create_index(
+                Index::create()
+                    .table(OauthAccounts::Table)
+                    .name("idx_oauth_accounts_user_id")
+                    .col(OauthAccounts::UserId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(OauthAccounts::Table)
+                    .name("idx_oauth_accounts_provider")
+                    .col(OauthAccounts::Provider)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(OauthAccounts::Table)
+                    .name("idx_oauth_accounts_subject")
+                    .col(OauthAccounts::Subject)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
             .create_table(
                 Table::create()
                     .table(PkceVerifiers::Table)
@@ -42,7 +76,25 @@ impl MigrationTrait for CreateOAuthAccounts {
             )
             .await?;
 
-        // TODO: Add indexes
+        manager
+            .create_index(
+                Index::create()
+                    .table(PkceVerifiers::Table)
+                    .name("idx_pkce_verifiers_csrf_state")
+                    .col(PkceVerifiers::CsrfState)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(PkceVerifiers::Table)
+                    .name("idx_pkce_verifiers_expires_at")
+                    .col(PkceVerifiers::ExpiresAt)
+                    .to_owned(),
+            )
+            .await?;
 
         Ok(())
     }

--- a/torii-storage-seaorm/src/migrations/m20250304_000004_create_passkeys_table.rs
+++ b/torii-storage-seaorm/src/migrations/m20250304_000004_create_passkeys_table.rs
@@ -1,4 +1,8 @@
-use sea_orm::{DbErr, DeriveMigrationName, prelude::*, sea_query::Table};
+use sea_orm::{
+    DbErr, DeriveMigrationName,
+    prelude::*,
+    sea_query::{Index, Table},
+};
 use sea_orm_migration::{
     MigrationTrait, SchemaManager,
     schema::{pk_auto, string, timestamp},
@@ -36,6 +40,26 @@ impl MigrationTrait for CreatePasskeys {
             .await?;
 
         manager
+            .create_index(
+                Index::create()
+                    .table(Passkeys::Table)
+                    .name("idx_passkeys_user_id")
+                    .col(Passkeys::UserId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(Passkeys::Table)
+                    .name("idx_passkeys_credential_id")
+                    .col(Passkeys::CredentialId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
             .create_table(
                 Table::create()
                     .table(PasskeyChallenges::Table)
@@ -50,7 +74,25 @@ impl MigrationTrait for CreatePasskeys {
             )
             .await?;
 
-        // TODO: Add indexes
+        manager
+            .create_index(
+                Index::create()
+                    .table(PasskeyChallenges::Table)
+                    .name("idx_passkey_challenges_challenge_id")
+                    .col(PasskeyChallenges::ChallengeId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(PasskeyChallenges::Table)
+                    .name("idx_passkey_challenges_expires_at")
+                    .col(PasskeyChallenges::ExpiresAt)
+                    .to_owned(),
+            )
+            .await?;
 
         Ok(())
     }

--- a/torii-storage-seaorm/src/migrations/m20250304_000004_create_passkeys_table.rs
+++ b/torii-storage-seaorm/src/migrations/m20250304_000004_create_passkeys_table.rs
@@ -1,0 +1,69 @@
+use sea_orm::{DbErr, DeriveMigrationName, prelude::*, sea_query::Table};
+use sea_orm_migration::{
+    MigrationTrait, SchemaManager,
+    schema::{pk_uuid, string, timestamp},
+};
+
+use super::{PasskeyChallenges, Passkeys};
+
+#[derive(DeriveMigrationName)]
+pub struct CreatePasskeys;
+
+#[async_trait::async_trait]
+impl MigrationTrait for CreatePasskeys {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(Passkeys::Table)
+                    .if_not_exists()
+                    .col(pk_uuid(Passkeys::Id).not_null())
+                    .col(string(Passkeys::UserId).not_null())
+                    .col(string(Passkeys::CredentialId).not_null())
+                    .col(string(Passkeys::DataJson).not_null())
+                    .col(
+                        timestamp(Passkeys::CreatedAt)
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .col(
+                        timestamp(Passkeys::UpdatedAt)
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(PasskeyChallenges::Table)
+                    .if_not_exists()
+                    .col(pk_uuid(PasskeyChallenges::Id).not_null())
+                    .col(string(PasskeyChallenges::ChallengeId).not_null())
+                    .col(string(PasskeyChallenges::Challenge).not_null())
+                    .col(
+                        timestamp(PasskeyChallenges::ExpiresAt)
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .col(
+                        timestamp(PasskeyChallenges::CreatedAt)
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .col(
+                        timestamp(PasskeyChallenges::UpdatedAt)
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // TODO: Add indexes
+
+        Ok(())
+    }
+}

--- a/torii-storage-seaorm/src/migrations/m20250304_000004_create_passkeys_table.rs
+++ b/torii-storage-seaorm/src/migrations/m20250304_000004_create_passkeys_table.rs
@@ -1,7 +1,7 @@
 use sea_orm::{DbErr, DeriveMigrationName, prelude::*, sea_query::Table};
 use sea_orm_migration::{
     MigrationTrait, SchemaManager,
-    schema::{pk_uuid, string, timestamp},
+    schema::{pk_auto, string, timestamp},
 };
 
 use super::{PasskeyChallenges, Passkeys};
@@ -17,7 +17,7 @@ impl MigrationTrait for CreatePasskeys {
                 Table::create()
                     .table(Passkeys::Table)
                     .if_not_exists()
-                    .col(pk_uuid(Passkeys::Id).not_null())
+                    .col(pk_auto(Passkeys::Id))
                     .col(string(Passkeys::UserId).not_null())
                     .col(string(Passkeys::CredentialId).not_null())
                     .col(string(Passkeys::DataJson).not_null())
@@ -40,24 +40,12 @@ impl MigrationTrait for CreatePasskeys {
                 Table::create()
                     .table(PasskeyChallenges::Table)
                     .if_not_exists()
-                    .col(pk_uuid(PasskeyChallenges::Id).not_null())
-                    .col(string(PasskeyChallenges::ChallengeId).not_null())
-                    .col(string(PasskeyChallenges::Challenge).not_null())
-                    .col(
-                        timestamp(PasskeyChallenges::ExpiresAt)
-                            .not_null()
-                            .default(Expr::current_timestamp()),
-                    )
-                    .col(
-                        timestamp(PasskeyChallenges::CreatedAt)
-                            .not_null()
-                            .default(Expr::current_timestamp()),
-                    )
-                    .col(
-                        timestamp(PasskeyChallenges::UpdatedAt)
-                            .not_null()
-                            .default(Expr::current_timestamp()),
-                    )
+                    .col(pk_auto(PasskeyChallenges::Id))
+                    .col(string(PasskeyChallenges::ChallengeId))
+                    .col(string(PasskeyChallenges::Challenge))
+                    .col(timestamp(PasskeyChallenges::ExpiresAt).default(Expr::current_timestamp()))
+                    .col(timestamp(PasskeyChallenges::CreatedAt).default(Expr::current_timestamp()))
+                    .col(timestamp(PasskeyChallenges::UpdatedAt).default(Expr::current_timestamp()))
                     .to_owned(),
             )
             .await?;

--- a/torii-storage-seaorm/src/migrations/m20250304_000005_create_magic_links.rs
+++ b/torii-storage-seaorm/src/migrations/m20250304_000005_create_magic_links.rs
@@ -1,7 +1,7 @@
 use sea_orm::{DbErr, DeriveMigrationName, prelude::*, sea_query::Table};
 use sea_orm_migration::{
     MigrationTrait, SchemaManager,
-    schema::{pk_uuid, string, timestamp},
+    schema::{pk_auto, string, timestamp, timestamp_null},
 };
 
 use super::MagicLinks;
@@ -17,21 +17,13 @@ impl MigrationTrait for CreateMagicLinks {
                 Table::create()
                     .table(MagicLinks::Table)
                     .if_not_exists()
-                    .col(pk_uuid(MagicLinks::Id).not_null())
-                    .col(string(MagicLinks::UserId).not_null())
-                    .col(string(MagicLinks::Token).not_null())
-                    .col(string(MagicLinks::UsedAt).not_null())
-                    .col(string(MagicLinks::ExpiresAt).not_null())
-                    .col(
-                        timestamp(MagicLinks::CreatedAt)
-                            .not_null()
-                            .default(Expr::current_timestamp()),
-                    )
-                    .col(
-                        timestamp(MagicLinks::UpdatedAt)
-                            .not_null()
-                            .default(Expr::current_timestamp()),
-                    )
+                    .col(pk_auto(MagicLinks::Id))
+                    .col(string(MagicLinks::UserId))
+                    .col(string(MagicLinks::Token))
+                    .col(timestamp_null(MagicLinks::UsedAt))
+                    .col(timestamp(MagicLinks::ExpiresAt))
+                    .col(timestamp(MagicLinks::CreatedAt).default(Expr::current_timestamp()))
+                    .col(timestamp(MagicLinks::UpdatedAt).default(Expr::current_timestamp()))
                     .to_owned(),
             )
             .await?;

--- a/torii-storage-seaorm/src/migrations/m20250304_000005_create_magic_links.rs
+++ b/torii-storage-seaorm/src/migrations/m20250304_000005_create_magic_links.rs
@@ -1,4 +1,8 @@
-use sea_orm::{DbErr, DeriveMigrationName, prelude::*, sea_query::Table};
+use sea_orm::{
+    DbErr, DeriveMigrationName,
+    prelude::*,
+    sea_query::{Index, Table},
+};
 use sea_orm_migration::{
     MigrationTrait, SchemaManager,
     schema::{pk_auto, string, timestamp, timestamp_null},
@@ -28,7 +32,35 @@ impl MigrationTrait for CreateMagicLinks {
             )
             .await?;
 
-        // TODO: Add indexes
+        manager
+            .create_index(
+                Index::create()
+                    .table(MagicLinks::Table)
+                    .name("idx_magic_links_user_id")
+                    .col(MagicLinks::UserId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(MagicLinks::Table)
+                    .name("idx_magic_links_token")
+                    .col(MagicLinks::Token)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(MagicLinks::Table)
+                    .name("idx_magic_links_expires_at")
+                    .col(MagicLinks::ExpiresAt)
+                    .to_owned(),
+            )
+            .await?;
 
         Ok(())
     }

--- a/torii-storage-seaorm/src/migrations/m20250304_000005_create_magic_links.rs
+++ b/torii-storage-seaorm/src/migrations/m20250304_000005_create_magic_links.rs
@@ -1,0 +1,43 @@
+use sea_orm::{DbErr, DeriveMigrationName, prelude::*, sea_query::Table};
+use sea_orm_migration::{
+    MigrationTrait, SchemaManager,
+    schema::{pk_uuid, string, timestamp},
+};
+
+use super::MagicLinks;
+
+#[derive(DeriveMigrationName)]
+pub struct CreateMagicLinks;
+
+#[async_trait::async_trait]
+impl MigrationTrait for CreateMagicLinks {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(MagicLinks::Table)
+                    .if_not_exists()
+                    .col(pk_uuid(MagicLinks::Id).not_null())
+                    .col(string(MagicLinks::UserId).not_null())
+                    .col(string(MagicLinks::Token).not_null())
+                    .col(string(MagicLinks::UsedAt).not_null())
+                    .col(string(MagicLinks::ExpiresAt).not_null())
+                    .col(
+                        timestamp(MagicLinks::CreatedAt)
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .col(
+                        timestamp(MagicLinks::UpdatedAt)
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // TODO: Add indexes
+
+        Ok(())
+    }
+}

--- a/torii-storage-seaorm/src/migrations/mod.rs
+++ b/torii-storage-seaorm/src/migrations/mod.rs
@@ -12,6 +12,7 @@ mod m20250304_000001_create_user_table;
 mod m20250304_000002_create_session_table;
 mod m20250304_000003_create_oauth_table;
 mod m20250304_000004_create_passkeys_table;
+mod m20250304_000005_create_magic_links;
 
 #[allow(dead_code)]
 pub struct Migrator;
@@ -96,6 +97,18 @@ pub enum PasskeyChallenges {
     Id,
     ChallengeId,
     Challenge,
+    ExpiresAt,
+    CreatedAt,
+    UpdatedAt,
+}
+
+#[derive(DeriveIden)]
+pub enum MagicLinks {
+    Table,
+    Id,
+    UserId,
+    Token,
+    UsedAt,
     ExpiresAt,
     CreatedAt,
     UpdatedAt,

--- a/torii-storage-seaorm/src/migrations/mod.rs
+++ b/torii-storage-seaorm/src/migrations/mod.rs
@@ -1,6 +1,7 @@
 use m20250304_000001_create_user_table::CreateUsers;
 use m20250304_000002_create_session_table::CreateSessions;
 
+use m20250304_000003_create_oauth_table::CreateOAuthAccounts;
 use sea_orm::{
     DeriveIden,
     sea_query::{Alias, IntoIden},
@@ -9,6 +10,7 @@ use sea_orm_migration::{MigrationTrait, MigratorTrait};
 
 mod m20250304_000001_create_user_table;
 mod m20250304_000002_create_session_table;
+mod m20250304_000003_create_oauth_table;
 
 #[allow(dead_code)]
 pub struct Migrator;
@@ -21,7 +23,11 @@ impl MigratorTrait for Migrator {
     }
 
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-        vec![Box::new(CreateUsers), Box::new(CreateSessions)]
+        vec![
+            Box::new(CreateUsers),
+            Box::new(CreateSessions),
+            Box::new(CreateOAuthAccounts),
+        ]
     }
 }
 
@@ -45,6 +51,28 @@ pub enum Sessions {
     Token,
     IpAddress,
     UserAgent,
+    ExpiresAt,
+    CreatedAt,
+    UpdatedAt,
+}
+
+#[derive(DeriveIden)]
+pub enum OauthAccounts {
+    Table,
+    Id,
+    UserId,
+    Provider,
+    Subject,
+    CreatedAt,
+    UpdatedAt,
+}
+
+#[derive(DeriveIden)]
+pub enum PkceVerifiers {
+    Table,
+    Id,
+    CsrfState,
+    Verifier,
     ExpiresAt,
     CreatedAt,
     UpdatedAt,

--- a/torii-storage-seaorm/src/migrations/mod.rs
+++ b/torii-storage-seaorm/src/migrations/mod.rs
@@ -11,6 +11,7 @@ use sea_orm_migration::{MigrationTrait, MigratorTrait};
 mod m20250304_000001_create_user_table;
 mod m20250304_000002_create_session_table;
 mod m20250304_000003_create_oauth_table;
+mod m20250304_000004_create_passkeys_table;
 
 #[allow(dead_code)]
 pub struct Migrator;
@@ -73,6 +74,28 @@ pub enum PkceVerifiers {
     Id,
     CsrfState,
     Verifier,
+    ExpiresAt,
+    CreatedAt,
+    UpdatedAt,
+}
+
+#[derive(DeriveIden)]
+pub enum Passkeys {
+    Table,
+    Id,
+    UserId,
+    CredentialId,
+    DataJson,
+    CreatedAt,
+    UpdatedAt,
+}
+
+#[derive(DeriveIden)]
+pub enum PasskeyChallenges {
+    Table,
+    Id,
+    ChallengeId,
+    Challenge,
     ExpiresAt,
     CreatedAt,
     UpdatedAt,

--- a/torii-storage-seaorm/src/migrations/mod.rs
+++ b/torii-storage-seaorm/src/migrations/mod.rs
@@ -1,0 +1,50 @@
+use m20250304_000001_create_user_table::CreateUsers;
+use m20250304_000002_create_session_table::CreateSessions;
+
+use sea_orm::{
+    DeriveIden,
+    sea_query::{Alias, IntoIden},
+};
+use sea_orm_migration::{MigrationTrait, MigratorTrait};
+
+mod m20250304_000001_create_user_table;
+mod m20250304_000002_create_session_table;
+
+#[allow(dead_code)]
+pub struct Migrator;
+
+#[async_trait::async_trait]
+impl MigratorTrait for Migrator {
+    // Override the name of migration table
+    fn migration_table_name() -> sea_orm::DynIden {
+        Alias::new("torii_migrations").into_iden()
+    }
+
+    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+        vec![Box::new(CreateUsers), Box::new(CreateSessions)]
+    }
+}
+
+#[derive(DeriveIden)]
+pub enum Users {
+    Table,
+    Id,
+    Email,
+    Name,
+    EmailVerifiedAt,
+    CreatedAt,
+    UpdatedAt,
+}
+
+#[derive(DeriveIden)]
+pub enum Sessions {
+    Table,
+    Id,
+    UserId,
+    Token,
+    IpAddress,
+    UserAgent,
+    ExpiresAt,
+    CreatedAt,
+    UpdatedAt,
+}

--- a/torii-storage-seaorm/src/migrations/mod.rs
+++ b/torii-storage-seaorm/src/migrations/mod.rs
@@ -31,6 +31,7 @@ pub enum Users {
     Id,
     Email,
     Name,
+    PasswordHash,
     EmailVerifiedAt,
     CreatedAt,
     UpdatedAt,

--- a/torii-storage-seaorm/src/oauth.rs
+++ b/torii-storage-seaorm/src/oauth.rs
@@ -1,0 +1,256 @@
+use chrono::Utc;
+use sea_orm::ActiveValue::Set;
+use sea_orm::prelude::Uuid;
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter};
+use torii_core::{OAuthAccount, User};
+use torii_core::{UserId, storage::OAuthStorage};
+
+use crate::{SeaORMStorage, SeaORMStorageError};
+
+use crate::entities::oauth;
+use crate::entities::pkce_verifier;
+use crate::entities::user;
+
+impl From<oauth::Model> for OAuthAccount {
+    fn from(value: oauth::Model) -> Self {
+        OAuthAccount::builder()
+            .user_id(UserId::new(value.id.as_str()))
+            .provider(value.provider)
+            .subject(value.subject)
+            .build()
+            .expect("Failed to build OAuthAccount")
+    }
+}
+
+#[async_trait::async_trait]
+impl OAuthStorage for SeaORMStorage {
+    type Error = SeaORMStorageError;
+
+    async fn create_oauth_account(
+        &self,
+        provider: &str,
+        subject: &str,
+        user_id: &UserId,
+    ) -> Result<OAuthAccount, <Self as OAuthStorage>::Error> {
+        let user = user::Entity::find_by_id(user_id.to_string())
+            .one(&self.pool)
+            .await?;
+
+        if let Some(user) = user {
+            let oauth_account = oauth::ActiveModel {
+                id: Set(Uuid::new_v4().to_string()),
+                user_id: Set(user.id),
+                provider: Set(provider.to_string()),
+                subject: Set(subject.to_string()),
+                created_at: Set(Utc::now()),
+                updated_at: Set(Utc::now()),
+            };
+            let oauth_account = oauth_account.insert(&self.pool).await?;
+
+            Ok(oauth_account.into())
+        } else {
+            Err(SeaORMStorageError::UserNotFound)
+        }
+    }
+
+    async fn get_user_by_provider_and_subject(
+        &self,
+        provider: &str,
+        subject: &str,
+    ) -> Result<Option<User>, <Self as OAuthStorage>::Error> {
+        let oauth_account = oauth::Entity::find()
+            .filter(oauth::Column::Provider.eq(provider))
+            .filter(oauth::Column::Subject.eq(subject))
+            .one(&self.pool)
+            .await?;
+
+        match oauth_account {
+            Some(oauth_account) => {
+                let user = user::Entity::find_by_id(oauth_account.user_id)
+                    .one(&self.pool)
+                    .await?;
+                let user = match user {
+                    Some(user) => user,
+                    None => return Err(SeaORMStorageError::UserNotFound),
+                };
+                Ok(Some(user.into()))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    async fn get_oauth_account_by_provider_and_subject(
+        &self,
+        provider: &str,
+        subject: &str,
+    ) -> Result<Option<OAuthAccount>, <Self as OAuthStorage>::Error> {
+        let oauth_account = oauth::Entity::find()
+            .filter(oauth::Column::Provider.eq(provider))
+            .filter(oauth::Column::Subject.eq(subject))
+            .one(&self.pool)
+            .await?;
+
+        match oauth_account {
+            Some(oauth_account) => Ok(Some(oauth_account.into())),
+            None => Ok(None),
+        }
+    }
+
+    async fn link_oauth_account(
+        &self,
+        user_id: &UserId,
+        provider: &str,
+        subject: &str,
+    ) -> Result<(), <Self as OAuthStorage>::Error> {
+        let user = user::Entity::find_by_id(user_id.to_string())
+            .one(&self.pool)
+            .await?;
+
+        let user = match user {
+            Some(user) => user,
+            None => return Err(SeaORMStorageError::UserNotFound),
+        };
+
+        let oauth_account = oauth::ActiveModel {
+            id: Set(Uuid::new_v4().to_string()),
+            user_id: Set(user.id),
+            provider: Set(provider.to_string()),
+            subject: Set(subject.to_string()),
+            created_at: Set(Utc::now()),
+            updated_at: Set(Utc::now()),
+        };
+        oauth_account.insert(&self.pool).await?;
+        Ok(())
+    }
+
+    async fn store_pkce_verifier(
+        &self,
+        csrf_state: &str,
+        pkce_verifier: &str,
+        expires_in: chrono::Duration,
+    ) -> Result<(), <Self as OAuthStorage>::Error> {
+        let pkce_verifier = pkce_verifier::ActiveModel {
+            id: Set(Uuid::new_v4().to_string()),
+            csrf_state: Set(csrf_state.to_string()),
+            verifier: Set(pkce_verifier.to_string()),
+            expires_at: Set(Utc::now() + expires_in),
+            created_at: Set(Utc::now()),
+            updated_at: Set(Utc::now()),
+        };
+        pkce_verifier.insert(&self.pool).await?;
+        Ok(())
+    }
+
+    async fn get_pkce_verifier(
+        &self,
+        csrf_state: &str,
+    ) -> Result<Option<String>, <Self as OAuthStorage>::Error> {
+        let pkce_verifier = pkce_verifier::Entity::find()
+            .filter(pkce_verifier::Column::CsrfState.eq(csrf_state))
+            .one(&self.pool)
+            .await?;
+
+        match pkce_verifier {
+            Some(pkce_verifier) => Ok(Some(pkce_verifier.verifier)),
+            None => Ok(None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Duration;
+    use sea_orm::{Database, DatabaseConnection};
+    use sea_orm_migration::MigratorTrait;
+
+    use super::*;
+    use crate::migrations::Migrator;
+
+    async fn setup_db() -> DatabaseConnection {
+        let pool = Database::connect("sqlite::memory:")
+            .await
+            .expect("Failed to connect to test db");
+        Migrator::up(&pool, None)
+            .await
+            .expect("Failed to run migrations");
+        pool
+    }
+
+    #[tokio::test]
+    async fn test_store_and_get_pkce_verifier() {
+        let pool = setup_db().await;
+        let storage = SeaORMStorage::new(pool);
+
+        let csrf_state = "test_state";
+        let pkce_verifier = "test_verifier";
+        let expires_in = Duration::hours(1);
+
+        // Store the verifier
+        storage
+            .store_pkce_verifier(csrf_state, pkce_verifier, expires_in)
+            .await
+            .expect("Failed to store PKCE verifier");
+
+        // Retrieve the verifier
+        let retrieved = storage
+            .get_pkce_verifier(csrf_state)
+            .await
+            .expect("Failed to get PKCE verifier");
+
+        assert_eq!(retrieved, Some(pkce_verifier.to_string()));
+
+        // Test non-existent verifier
+        let non_existent = storage
+            .get_pkce_verifier("non_existent")
+            .await
+            .expect("Failed to query non-existent verifier");
+
+        assert_eq!(non_existent, None);
+    }
+
+    #[tokio::test]
+    async fn test_store_oauth_account() {
+        let pool = setup_db().await;
+        let storage = SeaORMStorage::new(pool);
+
+        // First create a user
+        let user = user::ActiveModel {
+            id: Set(Uuid::new_v4().to_string()),
+            email: Set("test@example.com".to_string()),
+            name: Set(Some("Test User".to_string())),
+            password_hash: Set(None),
+            email_verified_at: Set(None),
+            created_at: Set(Utc::now()),
+            updated_at: Set(Utc::now()),
+        };
+        let user = user
+            .insert(&storage.pool)
+            .await
+            .expect("Failed to create user");
+
+        // Store OAuth account
+        storage
+            .create_oauth_account("google", "123456", &UserId::new(&user.id))
+            .await
+            .expect("Failed to store OAuth account");
+
+        // Verify OAuth account was stored
+        let oauth_account = oauth::Entity::find()
+            .filter(oauth::Column::UserId.eq(&user.id))
+            .one(&storage.pool)
+            .await
+            .expect("Failed to query OAuth account");
+
+        assert!(oauth_account.is_some());
+        let oauth_account = oauth_account.unwrap();
+        assert_eq!(oauth_account.provider, "google");
+        assert_eq!(oauth_account.subject, "123456");
+        assert_eq!(oauth_account.user_id, user.id);
+
+        // Test storing OAuth account for non-existent user
+        let result = storage
+            .create_oauth_account("non_existent", "google", &UserId::new("non_existent"))
+            .await;
+        assert!(matches!(result, Err(SeaORMStorageError::UserNotFound)));
+    }
+}

--- a/torii-storage-seaorm/src/passkey.rs
+++ b/torii-storage-seaorm/src/passkey.rs
@@ -20,12 +20,10 @@ impl PasskeyStorage for SeaORMStorage {
         passkey_json: &str,
     ) -> Result<(), <Self as PasskeyStorage>::Error> {
         let passkey = passkey::ActiveModel {
-            id: Set(Uuid::new_v4().to_string()),
             user_id: Set(user_id.to_string()),
             credential_id: Set(credential_id.to_string()),
             data_json: Set(passkey_json.to_string()),
-            created_at: Set(Utc::now()),
-            updated_at: Set(Utc::now()),
+            ..Default::default()
         };
 
         passkey.insert(&self.pool).await?;
@@ -64,12 +62,10 @@ impl PasskeyStorage for SeaORMStorage {
         expires_in: chrono::Duration,
     ) -> Result<(), <Self as PasskeyStorage>::Error> {
         let passkey_challenge = passkey_challenge::ActiveModel {
-            id: Set(Uuid::new_v4().to_string()),
             challenge_id: Set(challenge_id.to_string()),
             challenge: Set(challenge.to_string()),
             expires_at: Set(Utc::now() + expires_in),
-            created_at: Set(Utc::now()),
-            updated_at: Set(Utc::now()),
+            ..Default::default()
         };
 
         passkey_challenge.insert(&self.pool).await?;

--- a/torii-storage-seaorm/src/passkey.rs
+++ b/torii-storage-seaorm/src/passkey.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use chrono::Utc;
 use sea_orm::ActiveValue::Set;
-use sea_orm::prelude::Uuid;
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter};
 use torii_core::{UserId, storage::PasskeyStorage};
 

--- a/torii-storage-seaorm/src/passkey.rs
+++ b/torii-storage-seaorm/src/passkey.rs
@@ -1,0 +1,91 @@
+use async_trait::async_trait;
+use chrono::Utc;
+use sea_orm::ActiveValue::Set;
+use sea_orm::prelude::Uuid;
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter};
+use torii_core::{UserId, storage::PasskeyStorage};
+
+use crate::{SeaORMStorage, SeaORMStorageError};
+
+use crate::entities::{passkey, passkey_challenge};
+
+#[async_trait]
+impl PasskeyStorage for SeaORMStorage {
+    type Error = SeaORMStorageError;
+
+    async fn add_passkey(
+        &self,
+        user_id: &UserId,
+        credential_id: &str,
+        passkey_json: &str,
+    ) -> Result<(), <Self as PasskeyStorage>::Error> {
+        let passkey = passkey::ActiveModel {
+            id: Set(Uuid::new_v4().to_string()),
+            user_id: Set(user_id.to_string()),
+            credential_id: Set(credential_id.to_string()),
+            data_json: Set(passkey_json.to_string()),
+            created_at: Set(Utc::now()),
+            updated_at: Set(Utc::now()),
+        };
+
+        passkey.insert(&self.pool).await?;
+
+        Ok(())
+    }
+
+    async fn get_passkey_by_credential_id(
+        &self,
+        credential_id: &str,
+    ) -> Result<Option<String>, <Self as PasskeyStorage>::Error> {
+        let passkey = passkey::Entity::find()
+            .filter(passkey::Column::CredentialId.eq(credential_id))
+            .one(&self.pool)
+            .await?;
+
+        Ok(passkey.map(|p| p.data_json))
+    }
+
+    async fn get_passkeys(
+        &self,
+        user_id: &UserId,
+    ) -> Result<Vec<String>, <Self as PasskeyStorage>::Error> {
+        let passkeys = passkey::Entity::find()
+            .filter(passkey::Column::UserId.eq(user_id.to_string()))
+            .all(&self.pool)
+            .await?;
+
+        Ok(passkeys.into_iter().map(|p| p.data_json).collect())
+    }
+
+    async fn set_passkey_challenge(
+        &self,
+        challenge_id: &str,
+        challenge: &str,
+        expires_in: chrono::Duration,
+    ) -> Result<(), <Self as PasskeyStorage>::Error> {
+        let passkey_challenge = passkey_challenge::ActiveModel {
+            id: Set(Uuid::new_v4().to_string()),
+            challenge_id: Set(challenge_id.to_string()),
+            challenge: Set(challenge.to_string()),
+            expires_at: Set(Utc::now() + expires_in),
+            created_at: Set(Utc::now()),
+            updated_at: Set(Utc::now()),
+        };
+
+        passkey_challenge.insert(&self.pool).await?;
+
+        Ok(())
+    }
+
+    async fn get_passkey_challenge(
+        &self,
+        challenge_id: &str,
+    ) -> Result<Option<String>, <Self as PasskeyStorage>::Error> {
+        let passkey_challenge = passkey_challenge::Entity::find()
+            .filter(passkey_challenge::Column::ChallengeId.eq(challenge_id))
+            .one(&self.pool)
+            .await?;
+
+        Ok(passkey_challenge.map(|p| p.challenge))
+    }
+}

--- a/torii-storage-seaorm/src/password.rs
+++ b/torii-storage-seaorm/src/password.rs
@@ -1,0 +1,111 @@
+use sea_orm::ActiveValue::Set;
+use sea_orm::{ActiveModelTrait, EntityTrait};
+use torii_core::{UserId, storage::PasswordStorage};
+
+use crate::{SeaORMStorage, SeaORMStorageError};
+
+use crate::entities::user;
+
+#[async_trait::async_trait]
+impl PasswordStorage for SeaORMStorage {
+    type Error = SeaORMStorageError;
+
+    async fn set_password_hash(
+        &self,
+        user_id: &UserId,
+        password_hash: &str,
+    ) -> Result<(), <Self as PasswordStorage>::Error> {
+        let user: Option<user::ActiveModel> = user::Entity::find_by_id(user_id.as_str())
+            .one(&self.pool)
+            .await?
+            .map(|user| user.into());
+
+        if user.is_none() {
+            return Err(SeaORMStorageError::UserNotFound);
+        }
+
+        if let Some(mut user) = user {
+            user.password_hash = Set(Some(password_hash.to_string()));
+            user.update(&self.pool).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn get_password_hash(
+        &self,
+        user_id: &UserId,
+    ) -> Result<Option<String>, <Self as PasswordStorage>::Error> {
+        let user: Option<user::Model> = user::Entity::find_by_id(user_id.as_str())
+            .one(&self.pool)
+            .await?;
+
+        match user {
+            Some(user) => Ok(user.password_hash),
+            _ => Err(SeaORMStorageError::UserNotFound),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::Database;
+    use sea_orm_migration::MigratorTrait;
+    use torii_core::User;
+
+    use crate::entities::user;
+    use crate::migrations::Migrator;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_password_hash() {
+        let storage = SeaORMStorage::new(
+            Database::connect("sqlite::memory:")
+                .await
+                .expect("Failed to connect to db"),
+        );
+        Migrator::up(&storage.pool, None)
+            .await
+            .expect("Failed to run migrations");
+
+        // Create test user
+        let user = User::builder()
+            .id(UserId::new("1"))
+            .email("test@example.com".to_string())
+            .build()
+            .expect("Failed to build user");
+
+        let user_model = user::ActiveModel {
+            id: Set(user.id.as_str().to_owned()),
+            email: Set(user.email.to_owned()),
+            ..Default::default()
+        };
+        user_model
+            .insert(&storage.pool)
+            .await
+            .expect("Failed to create user");
+
+        // Set password hash
+        let hash = "test_hash_123";
+        storage
+            .set_password_hash(&user.id, hash)
+            .await
+            .expect("Failed to set password hash");
+
+        // Get password hash
+        let stored_hash = storage
+            .get_password_hash(&user.id)
+            .await
+            .expect("Failed to get password hash");
+
+        assert_eq!(stored_hash, Some(hash.to_string()));
+
+        // Get password hash for non-existent user
+        let result = storage
+            .get_password_hash(&UserId::new("non_existent"))
+            .await;
+
+        assert!(matches!(result, Err(SeaORMStorageError::UserNotFound)));
+    }
+}

--- a/torii-storage-seaorm/src/session.rs
+++ b/torii-storage-seaorm/src/session.rs
@@ -1,0 +1,221 @@
+use chrono::Utc;
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
+
+use torii_core::session::SessionId;
+use torii_core::{Session, SessionStorage, UserId};
+
+use crate::SeaORMStorage;
+use crate::entities::session;
+
+impl From<session::Model> for Session {
+    fn from(value: session::Model) -> Self {
+        Self {
+            id: SessionId::new(&value.id),
+            user_id: UserId::new(&value.user_id),
+            user_agent: value.user_agent.to_owned(),
+            ip_address: value.ip_address.to_owned(),
+            created_at: value.created_at.to_owned(),
+            updated_at: value.updated_at.to_owned(),
+            expires_at: value.expires_at.to_owned(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl SessionStorage for SeaORMStorage {
+    type Error = sea_orm::DbErr;
+
+    async fn create_session(&self, session: &Session) -> Result<Session, Self::Error> {
+        let s = session::ActiveModel {
+            // TODO: The id should be set by the database (or in ActiveModelBehavior)
+            id: Set(session.id.as_str().to_owned()),
+            user_id: Set(session.user_id.to_string()),
+            token: Set(session.id.as_str().to_owned()),
+            ip_address: Set(session.ip_address.to_owned()),
+            user_agent: Set(session.user_agent.to_owned()),
+            expires_at: Set(session.expires_at.to_owned()),
+            ..Default::default()
+        };
+
+        let result = s.insert(&self.pool).await?;
+
+        Ok(result.into())
+    }
+
+    async fn get_session(&self, id: &SessionId) -> Result<Option<Session>, Self::Error> {
+        let session = session::Entity::find_by_id(id.as_str())
+            .one(&self.pool)
+            .await?;
+
+        Ok(session.map(|s| s.into()))
+    }
+
+    async fn delete_session(&self, id: &SessionId) -> Result<(), Self::Error> {
+        session::Entity::delete_by_id(id.as_str())
+            .exec(&self.pool)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn cleanup_expired_sessions(&self) -> Result<(), Self::Error> {
+        session::Entity::delete_many()
+            .filter(session::Column::ExpiresAt.lt(Utc::now()))
+            .exec(&self.pool)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn delete_sessions_for_user(&self, user_id: &UserId) -> Result<(), Self::Error> {
+        session::Entity::delete_many()
+            .filter(session::Column::UserId.eq(user_id.as_str()))
+            .exec(&self.pool)
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::Database;
+    use sea_orm_migration::MigratorTrait;
+
+    use crate::migrations::Migrator;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_create_session() {
+        let storage = SeaORMStorage::new(Database::connect("sqlite::memory:").await.unwrap());
+        Migrator::up(&storage.pool, None).await.unwrap();
+
+        let session = Session::builder()
+            .user_id(UserId::new("1"))
+            .user_agent(Some("test".to_string()))
+            .ip_address(Some("127.0.0.1".to_string()))
+            .build()
+            .unwrap();
+
+        let created_session = storage.create_session(&session).await.unwrap();
+        assert_eq!(created_session.id, session.id);
+        assert_eq!(created_session.user_id, session.user_id);
+        assert_eq!(created_session.user_agent, session.user_agent);
+        assert_eq!(created_session.ip_address, session.ip_address);
+        assert_eq!(
+            created_session.created_at.timestamp(),
+            session.created_at.timestamp()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_session() {
+        let storage = SeaORMStorage::new(Database::connect("sqlite::memory:").await.unwrap());
+        Migrator::up(&storage.pool, None).await.unwrap();
+
+        let session = Session::builder()
+            .user_id(UserId::new("1"))
+            .user_agent(Some("test".to_string()))
+            .ip_address(Some("127.0.0.1".to_string()))
+            .build()
+            .unwrap();
+
+        let created_session = storage.create_session(&session).await.unwrap();
+        assert_eq!(created_session.id, session.id);
+        assert_eq!(created_session.user_id, session.user_id);
+        assert_eq!(created_session.user_agent, session.user_agent);
+        assert_eq!(created_session.ip_address, session.ip_address);
+
+        let retrieved_session = storage.get_session(&session.id).await.unwrap().unwrap();
+        assert_eq!(retrieved_session.id, session.id);
+        assert_eq!(retrieved_session.user_id, session.user_id);
+        assert_eq!(retrieved_session.user_agent, session.user_agent);
+        assert_eq!(retrieved_session.ip_address, session.ip_address);
+    }
+
+    #[tokio::test]
+    async fn test_delete_session() {
+        let storage = SeaORMStorage::new(Database::connect("sqlite::memory:").await.unwrap());
+        Migrator::up(&storage.pool, None).await.unwrap();
+
+        let session = Session::builder()
+            .user_id(UserId::new("1"))
+            .user_agent(Some("test".to_string()))
+            .ip_address(Some("127.0.0.1".to_string()))
+            .build()
+            .unwrap();
+
+        let created_session = storage.create_session(&session).await.unwrap();
+        assert_eq!(created_session.id, session.id);
+        assert_eq!(created_session.user_id, session.user_id);
+        assert_eq!(created_session.user_agent, session.user_agent);
+        assert_eq!(created_session.ip_address, session.ip_address);
+
+        storage.delete_session(&session.id).await.unwrap();
+
+        let retrieved_session = storage.get_session(&session.id).await.unwrap();
+        assert!(retrieved_session.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_expired_sessions() {
+        let storage = SeaORMStorage::new(Database::connect("sqlite::memory:").await.unwrap());
+        Migrator::up(&storage.pool, None).await.unwrap();
+
+        // Create valid session
+        let valid_session = Session::builder()
+            .user_id(UserId::new("1"))
+            .user_agent(Some("test".to_string()))
+            .ip_address(Some("127.0.0.1".to_string()))
+            .expires_at(Utc::now() + chrono::Duration::days(1))
+            .build()
+            .unwrap();
+        storage.create_session(&valid_session).await.unwrap();
+
+        // Create expired session
+        let expired_session = Session::builder()
+            .user_id(UserId::new("1"))
+            .user_agent(Some("test".to_string()))
+            .ip_address(Some("127.0.0.1".to_string()))
+            .expires_at(Utc::now() - chrono::Duration::days(1))
+            .build()
+            .unwrap();
+        storage.create_session(&expired_session).await.unwrap();
+
+        // Verify both sessions exist
+        assert!(
+            storage
+                .get_session(&valid_session.id)
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            storage
+                .get_session(&expired_session.id)
+                .await
+                .unwrap()
+                .is_some()
+        );
+
+        // Run cleanup
+        storage.cleanup_expired_sessions().await.unwrap();
+
+        // Verify expired session was removed but valid session remains
+        assert!(
+            storage
+                .get_session(&valid_session.id)
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            storage
+                .get_session(&expired_session.id)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+}

--- a/torii-storage-seaorm/src/user.rs
+++ b/torii-storage-seaorm/src/user.rs
@@ -1,0 +1,95 @@
+use chrono::Utc;
+use sea_orm::ColumnTrait;
+use sea_orm::QueryFilter;
+use sea_orm::{ActiveModelTrait, EntityTrait, Set};
+use torii_core::{NewUser, User as ToriiUser, UserId, UserStorage};
+
+use crate::SeaORMStorage;
+use crate::entities::user;
+
+impl From<user::Model> for ToriiUser {
+    fn from(user: user::Model) -> Self {
+        Self {
+            id: UserId::new(&user.id),
+            name: user.name.to_owned(),
+            email: user.email.to_owned(),
+            email_verified_at: user.email_verified_at.to_owned(),
+            created_at: user.created_at.to_owned(),
+            updated_at: user.updated_at.to_owned(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl UserStorage for SeaORMStorage {
+    type Error = sea_orm::DbErr;
+
+    async fn create_user(&self, user: &NewUser) -> Result<ToriiUser, Self::Error> {
+        let model = user::ActiveModel {
+            email: Set(user.email.to_owned()),
+            name: Set(user.name.to_owned()),
+            email_verified_at: Set(user.email_verified_at.to_owned()),
+            ..Default::default()
+        };
+
+        Ok(model.insert(&self.pool).await?.into())
+    }
+
+    async fn get_user(&self, id: &UserId) -> Result<Option<ToriiUser>, Self::Error> {
+        let user = user::Entity::find_by_id(id.as_str())
+            .one(&self.pool)
+            .await?;
+
+        Ok(user.map(ToriiUser::from))
+    }
+
+    async fn get_user_by_email(&self, email: &str) -> Result<Option<ToriiUser>, Self::Error> {
+        Ok(user::Entity::find()
+            .filter(user::Column::Email.eq(email))
+            .one(&self.pool)
+            .await?
+            .map(ToriiUser::from))
+    }
+
+    async fn get_or_create_user_by_email(&self, email: &str) -> Result<ToriiUser, Self::Error> {
+        let user = self.get_user_by_email(email).await?;
+
+        match user {
+            Some(user) => Ok(user),
+            None => {
+                self.create_user(&NewUser::builder().email(email.to_string()).build().unwrap())
+                    .await
+            }
+        }
+    }
+
+    async fn update_user(&self, user: &ToriiUser) -> Result<ToriiUser, Self::Error> {
+        let model = user::ActiveModel {
+            name: Set(user.name.to_owned()),
+            ..Default::default()
+        };
+
+        Ok(model.update(&self.pool).await?.into())
+    }
+
+    async fn delete_user(&self, id: &UserId) -> Result<(), Self::Error> {
+        let _ = user::Entity::delete_by_id(id.as_str())
+            .exec(&self.pool)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn set_user_email_verified(&self, user_id: &UserId) -> Result<(), Self::Error> {
+        let mut user: user::ActiveModel = user::Entity::find_by_id(user_id.as_str())
+            .one(&self.pool)
+            .await?
+            .unwrap()
+            .into();
+
+        user.email_verified_at = Set(Some(Utc::now()));
+        user.update(&self.pool).await?;
+
+        Ok(())
+    }
+}

--- a/torii-storage-sqlite/src/magic_link.rs
+++ b/torii-storage-sqlite/src/magic_link.rs
@@ -49,7 +49,12 @@ impl From<&MagicToken> for SqliteMagicToken {
 
 #[async_trait]
 impl MagicLinkStorage for SqliteStorage {
-    async fn save_magic_token(&self, token: &MagicToken) -> Result<(), Self::Error> {
+    type Error = StorageError;
+
+    async fn save_magic_token(
+        &self,
+        token: &MagicToken,
+    ) -> Result<(), <Self as MagicLinkStorage>::Error> {
         let row = SqliteMagicToken::from(token);
 
         sqlx::query("INSERT INTO magic_links (user_id, token, expires_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?)")
@@ -65,7 +70,10 @@ impl MagicLinkStorage for SqliteStorage {
         Ok(())
     }
 
-    async fn get_magic_token(&self, token: &str) -> Result<Option<MagicToken>, Self::Error> {
+    async fn get_magic_token(
+        &self,
+        token: &str,
+    ) -> Result<Option<MagicToken>, <Self as MagicLinkStorage>::Error> {
         let row: Option<SqliteMagicToken> = sqlx::query_as(
             r#"
             SELECT id, user_id, token, used_at, expires_at, created_at, updated_at 
@@ -82,7 +90,10 @@ impl MagicLinkStorage for SqliteStorage {
         Ok(row.map(|row| row.into()))
     }
 
-    async fn set_magic_token_used(&self, token: &str) -> Result<(), Self::Error> {
+    async fn set_magic_token_used(
+        &self,
+        token: &str,
+    ) -> Result<(), <Self as MagicLinkStorage>::Error> {
         sqlx::query("UPDATE magic_links SET used_at = ? WHERE token = ?")
             .bind(Utc::now().timestamp())
             .bind(token)

--- a/torii-storage-sqlite/src/passkey.rs
+++ b/torii-storage-sqlite/src/passkey.rs
@@ -7,12 +7,14 @@ use torii_core::storage::PasskeyStorage;
 
 #[async_trait]
 impl PasskeyStorage for SqliteStorage {
+    type Error = StorageError;
+
     async fn add_passkey(
         &self,
         user_id: &UserId,
         credential_id: &str,
         passkey_json: &str,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), <Self as PasskeyStorage>::Error> {
         sqlx::query(
             r#"
             INSERT INTO passkeys (id, user_id, public_key) 
@@ -31,7 +33,7 @@ impl PasskeyStorage for SqliteStorage {
     async fn get_passkey_by_credential_id(
         &self,
         credential_id: &str,
-    ) -> Result<Option<String>, Self::Error> {
+    ) -> Result<Option<String>, <Self as PasskeyStorage>::Error> {
         let passkey: Option<String> = sqlx::query_scalar(
             r#"
             SELECT public_key 
@@ -46,7 +48,10 @@ impl PasskeyStorage for SqliteStorage {
         Ok(passkey)
     }
 
-    async fn get_passkeys(&self, user_id: &UserId) -> Result<Vec<String>, Self::Error> {
+    async fn get_passkeys(
+        &self,
+        user_id: &UserId,
+    ) -> Result<Vec<String>, <Self as PasskeyStorage>::Error> {
         let passkeys: Vec<String> = sqlx::query_scalar(
             r#"
             SELECT public_key 
@@ -66,7 +71,7 @@ impl PasskeyStorage for SqliteStorage {
         challenge_id: &str,
         challenge: &str,
         expires_in: chrono::Duration,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), <Self as PasskeyStorage>::Error> {
         sqlx::query(
             r#"
             INSERT INTO passkey_challenges (id, challenge, expires_at) 
@@ -85,7 +90,7 @@ impl PasskeyStorage for SqliteStorage {
     async fn get_passkey_challenge(
         &self,
         challenge_id: &str,
-    ) -> Result<Option<String>, Self::Error> {
+    ) -> Result<Option<String>, <Self as PasskeyStorage>::Error> {
         let challenge: Option<String> = sqlx::query_scalar(
             r#"
             SELECT challenge 

--- a/torii-storage-sqlite/src/password.rs
+++ b/torii-storage-sqlite/src/password.rs
@@ -6,7 +6,13 @@ use torii_core::storage::PasswordStorage;
 
 #[async_trait]
 impl PasswordStorage for SqliteStorage {
-    async fn set_password_hash(&self, user_id: &UserId, hash: &str) -> Result<(), StorageError> {
+    type Error = StorageError;
+
+    async fn set_password_hash(
+        &self,
+        user_id: &UserId,
+        hash: &str,
+    ) -> Result<(), <Self as PasswordStorage>::Error> {
         sqlx::query("UPDATE users SET password_hash = $1 WHERE id = $2")
             .bind(hash)
             .bind(user_id.as_str())
@@ -16,7 +22,10 @@ impl PasswordStorage for SqliteStorage {
         Ok(())
     }
 
-    async fn get_password_hash(&self, user_id: &UserId) -> Result<Option<String>, StorageError> {
+    async fn get_password_hash(
+        &self,
+        user_id: &UserId,
+    ) -> Result<Option<String>, <Self as PasswordStorage>::Error> {
         let result = sqlx::query_scalar("SELECT password_hash FROM users WHERE id = $1")
             .bind(user_id.as_str())
             .fetch_optional(&self.pool)

--- a/torii-storage-sqlite/src/session.rs
+++ b/torii-storage-sqlite/src/session.rs
@@ -34,7 +34,7 @@ impl From<SqliteSession> for Session {
 impl From<Session> for SqliteSession {
     fn from(session: Session) -> Self {
         SqliteSession {
-            id: session.id.into_inner(),
+            id: session.token.into_inner(),
             user_id: session.user_id.into_inner(),
             user_agent: session.user_agent,
             ip_address: session.ip_address,
@@ -57,7 +57,7 @@ impl SessionStorage for SqliteStorage {
             RETURNING id, user_id, user_agent, ip_address, created_at, updated_at, expires_at
             "#,
         )
-            .bind(session.id.as_str())
+            .bind(session.token.as_str())
             .bind(session.user_id.as_str())
             .bind(&session.user_agent)
             .bind(&session.ip_address)
@@ -200,7 +200,7 @@ pub(crate) mod test {
 
         // Create an already expired session by setting expires_at in the past
         let expired_session = Session {
-            id: SessionId::new("expired"),
+            token: SessionId::new("expired"),
             user_id: UserId::new("1"),
             user_agent: None,
             ip_address: None,

--- a/torii-storage-sqlite/src/session.rs
+++ b/torii-storage-sqlite/src/session.rs
@@ -74,7 +74,7 @@ impl SessionStorage for SqliteStorage {
         Ok(session.into())
     }
 
-    async fn get_session(&self, id: &SessionId) -> Result<Session, Self::Error> {
+    async fn get_session(&self, id: &SessionId) -> Result<Option<Session>, Self::Error> {
         let session = sqlx::query_as::<_, SqliteSession>(
             r#"
             SELECT id, user_id, user_agent, ip_address, created_at, updated_at, expires_at
@@ -90,7 +90,7 @@ impl SessionStorage for SqliteStorage {
             StorageError::Database("Failed to get session".to_string())
         })?;
 
-        Ok(session.into())
+        Ok(Some(session.into()))
     }
 
     async fn delete_session(&self, id: &SessionId) -> Result<(), Self::Error> {
@@ -179,7 +179,7 @@ pub(crate) mod test {
             .get_session(&SessionId::new("1"))
             .await
             .expect("Failed to get session");
-        assert_eq!(fetched.user_id, UserId::new("1"));
+        assert_eq!(fetched.unwrap().user_id, UserId::new("1"));
 
         storage
             .delete_session(&SessionId::new("1"))
@@ -233,7 +233,7 @@ pub(crate) mod test {
             .get_session(&SessionId::new("valid"))
             .await
             .expect("Failed to get valid session");
-        assert_eq!(valid_session.user_id, UserId::new("1"));
+        assert_eq!(valid_session.unwrap().user_id, UserId::new("1"));
     }
 
     #[tokio::test]
@@ -280,6 +280,6 @@ pub(crate) mod test {
             .get_session(&SessionId::new("session3"))
             .await
             .expect("Failed to get session 3");
-        assert_eq!(session3.user_id, UserId::new("2"));
+        assert_eq!(session3.unwrap().user_id, UserId::new("2"));
     }
 }

--- a/torii/Cargo.toml
+++ b/torii/Cargo.toml
@@ -8,12 +8,17 @@ license.workspace = true
 
 [dependencies]
 torii-core = { path = "../torii-core", version = "0.2.2" }
+# auth plugins
 torii-auth-password = { path = "../torii-auth-password", version = "0.2.2", optional = true }
 torii-auth-oauth = { path = "../torii-auth-oauth", version = "0.2.2", optional = true }
 torii-auth-passkey = { path = "../torii-auth-passkey", version = "0.2.2", optional = true }
+torii-auth-magic-link = { path = "../torii-auth-magic-link", version = "0.2.2", optional = true }
+# storage backends
 torii-storage-sqlite = { path = "../torii-storage-sqlite", version = "0.2.2", optional = true }
 torii-storage-postgres = { path = "../torii-storage-postgres", version = "0.2.2", optional = true }
+torii-storage-seaorm = { path = "../torii-storage-seaorm", version = "0.2.2", optional = true }
 
+# dependencies
 chrono.workspace = true # TODO: Make this optional and expose std::time::Duration in APIs
 tracing.workspace = true
 thiserror.workspace = true
@@ -25,11 +30,20 @@ tokio = { workspace = true, features = ["full"] }
 tracing-subscriber = { workspace = true }
 
 [features]
-default = ["password", "sqlite"]
+default = ["password", "seaorm-sqlite"]
+
 # storage backends
 sqlite = ["dep:torii-storage-sqlite"]
 postgres = ["dep:torii-storage-postgres"]
+
+# seaorm storage backends
+seaorm-sqlite = ["dep:torii-storage-seaorm", "torii-storage-seaorm/sqlite"]
+seaorm-postgres = ["dep:torii-storage-seaorm", "torii-storage-seaorm/postgres"]
+seaorm-mysql = ["dep:torii-storage-seaorm", "torii-storage-seaorm/mysql"]
+seaorm = ["dep:torii-storage-seaorm", "torii-storage-seaorm/sqlite", "torii-storage-seaorm/postgres", "torii-storage-seaorm/mysql"]
+
 # auth plugins
 password = ["dep:torii-auth-password"]
 oauth = ["dep:torii-auth-oauth"]
 passkey = ["dep:torii-auth-passkey"]
+magic-link = ["dep:torii-auth-magic-link"]

--- a/torii/src/lib.rs
+++ b/torii/src/lib.rs
@@ -18,7 +18,7 @@
 //! Torii currently supports the following storage backends:
 //! - SQLite
 //! - PostgreSQL
-//! - MySQL (In Development)
+//! - MySQL
 //!
 //! ## Warning
 //!
@@ -51,7 +51,6 @@
 use std::sync::Arc;
 
 use chrono::Duration;
-use torii_auth_magic_link::MagicLinkPlugin;
 use torii_core::{
     PluginManager, SessionStorage,
     session::{DefaultSessionManager, SessionManager},
@@ -74,12 +73,23 @@ pub use torii_auth_oauth::{AuthorizationUrl, OAuthPlugin, providers::Provider};
 #[cfg(feature = "passkey")]
 pub use torii_auth_passkey::{PasskeyChallenge, PasskeyPlugin};
 
+#[cfg(feature = "magic-link")]
+pub use torii_auth_magic_link::MagicLinkPlugin;
+
 // Re-export storage backends
 #[cfg(feature = "sqlite")]
 pub use torii_storage_sqlite::SqliteStorage;
 
 #[cfg(feature = "postgres")]
 pub use torii_storage_postgres::PostgresStorage;
+
+#[cfg(any(
+    feature = "seaorm-sqlite",
+    feature = "seaorm-postgres",
+    feature = "seaorm-mysql",
+    feature = "seaorm"
+))]
+pub use torii_storage_seaorm::SeaORMStorage;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ToriiError {


### PR DESCRIPTION
By using SeaORM (I know, an ORM...) we can support SQLite, MySQL, and Postgres without any additional work to maintain each individual storage provider. If it works well, `torii-storage-sqlite` and `torii-storage-postgres` may be removed in favor of this crate. 

Closes #4 