### PR TITLE
Ensure UserId is treated as opaque string

### DIFF
--- a/examples/todos/src/routes.rs
+++ b/examples/todos/src/routes.rs
@@ -13,7 +13,7 @@ use axum_extra::extract::{
 };
 use serde::Deserialize;
 use serde_json::json;
-use torii::{SessionId, User};
+use torii::{SessionToken, User};
 use tracing::info;
 use uuid::Uuid;
 
@@ -219,7 +219,7 @@ async fn add_user_extension(
     if let Some(session_id) = session_id {
         let session = state
             .torii
-            .get_session(&SessionId::new(&session_id))
+            .get_session(&SessionToken::new(&session_id))
             .await
             .expect("Failed to get session");
 
@@ -258,7 +258,7 @@ async fn whoami_handler(State(state): State<AppState>, jar: CookieJar) -> Respon
     if let Some(session_id) = session_id {
         let session = state
             .torii
-            .get_session(&SessionId::new(&session_id))
+            .get_session(&SessionToken::new(&session_id))
             .await
             .expect("Failed to get session");
 

--- a/torii-auth-magic-link/examples/magic_link.rs
+++ b/torii-auth-magic-link/examples/magic_link.rs
@@ -20,7 +20,7 @@ use torii_auth_magic_link::MagicLinkPlugin;
 use torii_core::{
     Session,
     plugin::PluginManager,
-    session::SessionId,
+    session::SessionToken,
     storage::{SessionStorage, UserStorage},
 };
 use torii_storage_sqlite::SqliteStorage;
@@ -168,7 +168,7 @@ async fn verify_session<B>(
     state
         .plugin_manager
         .session_storage()
-        .get_session(&SessionId::new(
+        .get_session(&SessionToken::new(
             &session_id.expect("session_id is required"),
         ))
         .await
@@ -197,7 +197,7 @@ async fn whoami_handler(State(state): State<AppState>, jar: CookieJar) -> Respon
     let session = state
         .plugin_manager
         .session_storage()
-        .get_session(&SessionId::new(
+        .get_session(&SessionToken::new(
             &session_id.expect("session_id is required"),
         ))
         .await

--- a/torii-auth-passkey/examples/passkey.rs
+++ b/torii-auth-passkey/examples/passkey.rs
@@ -15,7 +15,7 @@ use serde_json::json;
 use sqlx::{Pool, Sqlite};
 use torii_auth_passkey::PasskeyPlugin;
 use torii_core::{
-    Session, plugin::PluginManager, session::SessionId, storage::SessionStorage,
+    Session, plugin::PluginManager, session::SessionToken, storage::SessionStorage,
     storage::UserStorage,
 };
 use torii_storage_sqlite::SqliteStorage;
@@ -121,7 +121,7 @@ async fn whoami_handler(State(state): State<AppState>, jar: CookieJar) -> Respon
         let session = state
             .plugin_manager
             .session_storage()
-            .get_session(&SessionId::new(&session_id))
+            .get_session(&SessionToken::new(&session_id))
             .await
             .unwrap();
 
@@ -160,7 +160,7 @@ async fn verify_session<B>(
         state
             .plugin_manager
             .session_storage()
-            .get_session(&SessionId::new(&session_id))
+            .get_session(&SessionToken::new(&session_id))
             .await
             .unwrap();
 

--- a/torii-auth-password/examples/password.rs
+++ b/torii-auth-password/examples/password.rs
@@ -20,7 +20,7 @@ use torii_auth_password::PasswordPlugin;
 use torii_core::{
     Session,
     plugin::PluginManager,
-    session::SessionId,
+    session::SessionToken,
     storage::{SessionStorage, UserStorage},
 };
 use torii_storage_sqlite::SqliteStorage;
@@ -179,7 +179,7 @@ async fn verify_session<B>(
         state
             .plugin_manager
             .session_storage()
-            .get_session(&SessionId::new(&session_id))
+            .get_session(&SessionToken::new(&session_id))
             .await
             .unwrap();
 
@@ -201,7 +201,7 @@ async fn whoami_handler(State(state): State<AppState>, jar: CookieJar) -> Respon
         let session = state
             .plugin_manager
             .session_storage()
-            .get_session(&SessionId::new(&session_id))
+            .get_session(&SessionToken::new(&session_id))
             .await
             .unwrap();
 

--- a/torii-core/src/events.rs
+++ b/torii-core/src/events.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use tokio::sync::RwLock;
 
-use crate::{Session, User, UserId, error::EventError, session::SessionId};
+use crate::{Session, User, UserId, error::EventError, session::SessionToken};
 
 /// Represents events that can be emitted by the event bus
 ///
@@ -19,7 +19,7 @@ pub enum Event {
     UserUpdated(User),
     UserDeleted(UserId),
     SessionCreated(UserId, Session),
-    SessionDeleted(UserId, SessionId),
+    SessionDeleted(UserId, SessionToken),
     SessionsCleared(UserId),
 }
 
@@ -147,7 +147,7 @@ impl EventBus {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::session::SessionId;
+    use crate::session::SessionToken;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     struct TestEventHandler {
@@ -269,7 +269,7 @@ mod tests {
             .expect("Failed to build test user");
 
         let test_session = Session::builder()
-            .id(SessionId::new("test"))
+            .token(SessionToken::new("test"))
             .user_id(test_user.id.clone())
             .build()
             .expect("Failed to build test session");

--- a/torii-core/src/plugin.rs
+++ b/torii-core/src/plugin.rs
@@ -135,7 +135,7 @@ impl Default for SessionCleanupConfig {
 mod tests {
     use async_trait::async_trait;
 
-    use crate::{Error, NewUser, Session, User, UserId, session::SessionId};
+    use crate::{Error, NewUser, Session, User, UserId, session::SessionToken};
 
     use super::*;
 
@@ -156,7 +156,7 @@ mod tests {
 
     struct TestStorage {
         users: DashMap<UserId, User>,
-        sessions: DashMap<SessionId, Session>,
+        sessions: DashMap<SessionToken, Session>,
     }
 
     impl TestStorage {
@@ -236,7 +236,7 @@ mod tests {
     impl SessionStorage for TestStorage {
         type Error = Error;
 
-        async fn get_session(&self, id: &SessionId) -> Result<Option<Session>, Self::Error> {
+        async fn get_session(&self, id: &SessionToken) -> Result<Option<Session>, Self::Error> {
             Ok(self.sessions.get(id).map(|s| s.clone()))
         }
 
@@ -245,7 +245,7 @@ mod tests {
             Ok(session.clone())
         }
 
-        async fn delete_session(&self, id: &SessionId) -> Result<(), Self::Error> {
+        async fn delete_session(&self, id: &SessionToken) -> Result<(), Self::Error> {
             self.sessions.remove(id);
             Ok(())
         }
@@ -285,7 +285,7 @@ mod tests {
 
         // Create an expired session
         let expired_session = Session {
-            token: SessionId::new("expired"),
+            token: SessionToken::new("expired"),
             user_id: UserId::new("test"),
             user_agent: None,
             ip_address: None,
@@ -300,7 +300,7 @@ mod tests {
 
         // Create a valid session
         let valid_session = Session {
-            token: SessionId::new("valid"),
+            token: SessionToken::new("valid"),
             user_id: UserId::new("test"),
             user_agent: None,
             ip_address: None,

--- a/torii-core/src/storage.rs
+++ b/torii-core/src/storage.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    Error, OAuthAccount, Session, User, UserId, error::ValidationError, session::SessionId,
+    Error, OAuthAccount, Session, User, UserId, error::ValidationError, session::SessionToken,
 };
 
 #[async_trait]
@@ -38,8 +38,8 @@ pub trait SessionStorage: Send + Sync + 'static {
     type Error: std::error::Error + Send + Sync + 'static;
 
     async fn create_session(&self, session: &Session) -> Result<Session, Self::Error>;
-    async fn get_session(&self, id: &SessionId) -> Result<Option<Session>, Self::Error>;
-    async fn delete_session(&self, id: &SessionId) -> Result<(), Self::Error>;
+    async fn get_session(&self, token: &SessionToken) -> Result<Option<Session>, Self::Error>;
+    async fn delete_session(&self, token: &SessionToken) -> Result<(), Self::Error>;
     async fn cleanup_expired_sessions(&self) -> Result<(), Self::Error>;
     async fn delete_sessions_for_user(&self, user_id: &UserId) -> Result<(), Self::Error>;
 }

--- a/torii-core/src/user.rs
+++ b/torii-core/src/user.rs
@@ -19,6 +19,7 @@ use uuid::Uuid;
 use crate::{Error, error::ValidationError};
 
 /// A unique, stable identifier for a specific user
+/// This value should be treated as opaque, and should not be used as a UUID even if it may look like one
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct UserId(String);
 

--- a/torii-core/src/user.rs
+++ b/torii-core/src/user.rs
@@ -35,10 +35,6 @@ impl UserId {
         self.0
     }
 
-    pub fn as_uuid(&self) -> Uuid {
-        Uuid::parse_str(&self.0).unwrap()
-    }
-
     pub fn as_str(&self) -> &str {
         &self.0
     }

--- a/torii-storage-postgres/src/lib.rs
+++ b/torii-storage-postgres/src/lib.rs
@@ -105,8 +105,8 @@ impl UserStorage for PostgresStorage {
         let user = sqlx::query_as::<_, PostgresUser>(
             r#"
             INSERT INTO users (id, email) 
-            VALUES ($1::uuid, $2) 
-            RETURNING id::text, email, name, email_verified_at, created_at, updated_at
+            VALUES ($1, $2) 
+            RETURNING id, email, name, email_verified_at, created_at, updated_at
             "#,
         )
         .bind(user.id.as_str())
@@ -124,9 +124,9 @@ impl UserStorage for PostgresStorage {
     async fn get_user(&self, id: &UserId) -> Result<Option<User>, Self::Error> {
         let user = sqlx::query_as::<_, PostgresUser>(
             r#"
-            SELECT id::text, email, name, email_verified_at, created_at, updated_at 
+            SELECT id, email, name, email_verified_at, created_at, updated_at 
             FROM users 
-            WHERE id::text = $1
+            WHERE id = $1
             "#,
         )
         .bind(id.as_str())
@@ -146,7 +146,7 @@ impl UserStorage for PostgresStorage {
     async fn get_user_by_email(&self, email: &str) -> Result<Option<User>, Self::Error> {
         let user = sqlx::query_as::<_, PostgresUser>(
             r#"
-            SELECT id::text, email, name, email_verified_at, created_at, updated_at 
+            SELECT id, email, name, email_verified_at, created_at, updated_at 
             FROM users 
             WHERE email = $1
             "#,
@@ -193,8 +193,8 @@ impl UserStorage for PostgresStorage {
             r#"
             UPDATE users 
             SET email = $1, name = $2, email_verified_at = $3, updated_at = $4 
-            WHERE id::text = $5
-            RETURNING id::text, email, name, email_verified_at, created_at, updated_at
+            WHERE id = $5
+            RETURNING id, email, name, email_verified_at, created_at, updated_at
             "#,
         )
         .bind(&user.email)
@@ -213,7 +213,7 @@ impl UserStorage for PostgresStorage {
     }
 
     async fn delete_user(&self, id: &UserId) -> Result<(), Self::Error> {
-        sqlx::query("DELETE FROM users WHERE id::text = $1")
+        sqlx::query("DELETE FROM users WHERE id = $1")
             .bind(id.as_str())
             .execute(&self.pool)
             .await
@@ -226,7 +226,7 @@ impl UserStorage for PostgresStorage {
     }
 
     async fn set_user_email_verified(&self, user_id: &UserId) -> Result<(), Self::Error> {
-        sqlx::query("UPDATE users SET email_verified_at = $1 WHERE id::text = $2")
+        sqlx::query("UPDATE users SET email_verified_at = $1 WHERE id = $2")
             .bind(Utc::now())
             .bind(user_id.as_str())
             .execute(&self.pool)

--- a/torii-storage-postgres/src/lib.rs
+++ b/torii-storage-postgres/src/lib.rs
@@ -246,7 +246,7 @@ mod tests {
     use rand::Rng;
     use sqlx::types::chrono::Utc;
     use std::time::Duration;
-    use torii_core::session::SessionId;
+    use torii_core::session::SessionToken;
     use torii_core::{Session, SessionStorage};
 
     pub(crate) async fn setup_test_db() -> PostgresStorage {
@@ -301,7 +301,7 @@ mod tests {
 
     pub(crate) async fn create_test_session(
         storage: &PostgresStorage,
-        session_id: &SessionId,
+        session_token: &SessionToken,
         user_id: &UserId,
         expires_in: Duration,
     ) -> Result<Session, torii_core::Error> {
@@ -309,7 +309,7 @@ mod tests {
         storage
             .create_session(
                 &Session::builder()
-                    .id(session_id.clone())
+                    .token(session_token.clone())
                     .user_id(user_id.clone())
                     .user_agent(Some("test".to_string()))
                     .ip_address(Some("127.0.0.1".to_string()))

--- a/torii-storage-postgres/src/magic_link.rs
+++ b/torii-storage-postgres/src/magic_link.rs
@@ -56,7 +56,7 @@ impl MagicLinkStorage for PostgresStorage {
     ) -> Result<(), <Self as MagicLinkStorage>::Error> {
         let row = PostgresMagicToken::from(token);
 
-        sqlx::query("INSERT INTO magic_links (user_id, token, expires_at, created_at, updated_at) VALUES ($1::uuid, $2, $3, $4, $5)")
+        sqlx::query("INSERT INTO magic_links (user_id, token, expires_at, created_at, updated_at) VALUES ($1, $2, $3, $4, $5)")
             .bind(row.user_id)
             .bind(row.token)
             .bind(row.expires_at)
@@ -75,7 +75,7 @@ impl MagicLinkStorage for PostgresStorage {
     ) -> Result<Option<MagicToken>, <Self as MagicLinkStorage>::Error> {
         let row: Option<PostgresMagicToken> =
             sqlx::query_as(
-                "SELECT id, user_id::text, token, used_at, expires_at, created_at, updated_at FROM magic_links WHERE token = $1 AND expires_at > $2 AND used_at IS NULL",
+                "SELECT id, user_id, token, used_at, expires_at, created_at, updated_at FROM magic_links WHERE token = $1 AND expires_at > $2 AND used_at IS NULL",
             )
             .bind(token)
                 .bind(Utc::now())

--- a/torii-storage-postgres/src/magic_link.rs
+++ b/torii-storage-postgres/src/magic_link.rs
@@ -10,7 +10,7 @@ use crate::PostgresStorage;
 
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct PostgresMagicToken {
-    pub id: Option<String>,
+    pub id: Option<i64>,
     pub user_id: String,
     pub token: String,
     pub used_at: Option<DateTime<Utc>>,
@@ -75,7 +75,7 @@ impl MagicLinkStorage for PostgresStorage {
     ) -> Result<Option<MagicToken>, <Self as MagicLinkStorage>::Error> {
         let row: Option<PostgresMagicToken> =
             sqlx::query_as(
-                "SELECT id::text, user_id::text, token, used_at, expires_at, created_at, updated_at FROM magic_links WHERE token = $1 AND expires_at > $2 AND used_at IS NULL",
+                "SELECT id, user_id::text, token, used_at, expires_at, created_at, updated_at FROM magic_links WHERE token = $1 AND expires_at > $2 AND used_at IS NULL",
             )
             .bind(token)
                 .bind(Utc::now())

--- a/torii-storage-postgres/src/migrations/mod.rs
+++ b/torii-storage-postgres/src/migrations/mod.rs
@@ -201,10 +201,11 @@ impl Migration<Postgres> for CreateSessionsTable {
         sqlx::query(
             r#"
             CREATE TABLE IF NOT EXISTS sessions (
-                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
                 user_id UUID NOT NULL,
                 user_agent TEXT,
                 ip_address TEXT,
+                token TEXT NOT NULL,
                 expires_at TIMESTAMPTZ NOT NULL,
                 created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                 updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -246,7 +247,7 @@ impl Migration<Postgres> for CreateOAuthAccountsTable {
         sqlx::query(
             r#"
             CREATE TABLE IF NOT EXISTS oauth_accounts (
-                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
                 user_id UUID NOT NULL,
                 provider TEXT NOT NULL,
                 subject TEXT NOT NULL,
@@ -291,7 +292,7 @@ impl Migration<Postgres> for CreatePasskeysTable {
         sqlx::query(
             r#"
             CREATE TABLE IF NOT EXISTS passkeys (
-                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
                 credential_id TEXT NOT NULL,
                 user_id UUID NOT NULL,
                 public_key TEXT NOT NULL,
@@ -335,11 +336,13 @@ impl Migration<Postgres> for CreatePasskeyChallengesTable {
         sqlx::query(
             r#"
             CREATE TABLE IF NOT EXISTS passkey_challenges (
-                id TEXT PRIMARY KEY,
+                id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+                challenge_id TEXT NOT NULL,
                 challenge TEXT NOT NULL,
                 expires_at TIMESTAMPTZ NOT NULL,
                 created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                UNIQUE(challenge_id)
             );"#,
         )
         .execute(conn)
@@ -475,7 +478,7 @@ impl Migration<Postgres> for CreateMagicLinksTable {
         sqlx::query(
             r#"
             CREATE TABLE IF NOT EXISTS magic_links (
-                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
                 user_id UUID NOT NULL,
                 token TEXT NOT NULL,
                 used_at TIMESTAMPTZ,

--- a/torii-storage-postgres/src/migrations/mod.rs
+++ b/torii-storage-postgres/src/migrations/mod.rs
@@ -155,7 +155,7 @@ impl Migration<Postgres> for CreateUsersTable {
         sqlx::query(
             r#"
             CREATE TABLE IF NOT EXISTS users (
-                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
                 name TEXT,
                 email TEXT NOT NULL,
                 email_verified_at TIMESTAMPTZ,
@@ -202,7 +202,7 @@ impl Migration<Postgres> for CreateSessionsTable {
             r#"
             CREATE TABLE IF NOT EXISTS sessions (
                 id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-                user_id UUID NOT NULL,
+                user_id TEXT NOT NULL,
                 user_agent TEXT,
                 ip_address TEXT,
                 token TEXT NOT NULL,
@@ -248,7 +248,7 @@ impl Migration<Postgres> for CreateOAuthAccountsTable {
             r#"
             CREATE TABLE IF NOT EXISTS oauth_accounts (
                 id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-                user_id UUID NOT NULL,
+                user_id TEXT NOT NULL,
                 provider TEXT NOT NULL,
                 subject TEXT NOT NULL,
                 created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -294,7 +294,7 @@ impl Migration<Postgres> for CreatePasskeysTable {
             CREATE TABLE IF NOT EXISTS passkeys (
                 id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
                 credential_id TEXT NOT NULL,
-                user_id UUID NOT NULL,
+                user_id TEXT NOT NULL,
                 public_key TEXT NOT NULL,
                 created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                 updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -479,7 +479,7 @@ impl Migration<Postgres> for CreateMagicLinksTable {
             r#"
             CREATE TABLE IF NOT EXISTS magic_links (
                 id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-                user_id UUID NOT NULL,
+                user_id TEXT NOT NULL,
                 token TEXT NOT NULL,
                 used_at TIMESTAMPTZ,
                 expires_at TIMESTAMPTZ NOT NULL,

--- a/torii-storage-postgres/src/oauth.rs
+++ b/torii-storage-postgres/src/oauth.rs
@@ -44,6 +44,7 @@ impl PostgresOAuthAccountBuilder {
     pub fn build(self) -> Result<PostgresOAuthAccount, torii_core::Error> {
         let now = Utc::now();
         Ok(PostgresOAuthAccount {
+            id: None,
             user_id: self
                 .user_id
                 .ok_or(ValidationError::MissingField(
@@ -64,11 +65,12 @@ impl PostgresOAuthAccountBuilder {
 
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct PostgresOAuthAccount {
-    user_id: String,
-    provider: String,
-    subject: String,
-    created_at: DateTime<Utc>,
-    updated_at: DateTime<Utc>,
+    pub id: Option<i64>,
+    pub user_id: String,
+    pub provider: String,
+    pub subject: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
 }
 
 impl PostgresOAuthAccount {
@@ -141,7 +143,7 @@ impl OAuthStorage for PostgresStorage {
 
         let oauth_account = sqlx::query_as::<_, PostgresOAuthAccount>(
             r#"
-            SELECT user_id::text, provider, subject, created_at, updated_at
+            SELECT id, user_id::text, provider, subject, created_at, updated_at
             FROM oauth_accounts
             WHERE user_id::text = $1
             "#,
@@ -203,7 +205,7 @@ impl OAuthStorage for PostgresStorage {
     ) -> Result<Option<OAuthAccount>, <Self as OAuthStorage>::Error> {
         let oauth_account = sqlx::query_as::<_, PostgresOAuthAccount>(
             r#"
-            SELECT user_id::text, provider, subject, created_at, updated_at
+            SELECT id, user_id::text, provider, subject, created_at, updated_at
             FROM oauth_accounts
             WHERE provider = $1 AND subject = $2
             "#,

--- a/torii-storage-postgres/src/oauth.rs
+++ b/torii-storage-postgres/src/oauth.rs
@@ -128,7 +128,7 @@ impl OAuthStorage for PostgresStorage {
         subject: &str,
         user_id: &UserId,
     ) -> Result<OAuthAccount, <Self as OAuthStorage>::Error> {
-        sqlx::query("INSERT INTO oauth_accounts (user_id, provider, subject, created_at, updated_at) VALUES ($1::uuid, $2, $3, $4, $5)")
+        sqlx::query("INSERT INTO oauth_accounts (user_id, provider, subject, created_at, updated_at) VALUES ($1, $2, $3, $4, $5)")
             .bind(user_id.as_str())
             .bind(provider)
             .bind(subject)
@@ -143,9 +143,9 @@ impl OAuthStorage for PostgresStorage {
 
         let oauth_account = sqlx::query_as::<_, PostgresOAuthAccount>(
             r#"
-            SELECT id, user_id::text, provider, subject, created_at, updated_at
+            SELECT id, user_id, provider, subject, created_at, updated_at
             FROM oauth_accounts
-            WHERE user_id::text = $1
+            WHERE user_id = $1
             "#,
         )
         .bind(user_id.as_str())
@@ -166,7 +166,7 @@ impl OAuthStorage for PostgresStorage {
         expires_in: chrono::Duration,
     ) -> Result<(), <Self as OAuthStorage>::Error> {
         sqlx::query(
-            "INSERT INTO oauth_state (csrf_state, pkce_verifier, expires_at) VALUES ($1::text, $2, $3) RETURNING value",
+            "INSERT INTO oauth_state (csrf_state, pkce_verifier, expires_at) VALUES ($1, $2, $3) RETURNING value",
         )
         .bind(csrf_state)
         .bind(pkce_verifier)
@@ -205,7 +205,7 @@ impl OAuthStorage for PostgresStorage {
     ) -> Result<Option<OAuthAccount>, <Self as OAuthStorage>::Error> {
         let oauth_account = sqlx::query_as::<_, PostgresOAuthAccount>(
             r#"
-            SELECT id, user_id::text, provider, subject, created_at, updated_at
+            SELECT id, user_id, provider, subject, created_at, updated_at
             FROM oauth_accounts
             WHERE provider = $1 AND subject = $2
             "#,
@@ -233,7 +233,7 @@ impl OAuthStorage for PostgresStorage {
     ) -> Result<Option<User>, <Self as OAuthStorage>::Error> {
         let user = sqlx::query_as::<_, PostgresUser>(
             r#"
-            SELECT id::text, email, name, email_verified_at, created_at, updated_at
+            SELECT id, email, name, email_verified_at, created_at, updated_at
             FROM users
             WHERE provider = $1 AND subject = $2
             "#,
@@ -260,7 +260,7 @@ impl OAuthStorage for PostgresStorage {
         provider: &str,
         subject: &str,
     ) -> Result<(), <Self as OAuthStorage>::Error> {
-        sqlx::query("INSERT INTO oauth_accounts (user_id, provider, subject, created_at, updated_at) VALUES ($1::uuid, $2, $3, $4, $5)")
+        sqlx::query("INSERT INTO oauth_accounts (user_id, provider, subject, created_at, updated_at) VALUES ($1, $2, $3, $4, $5)")
             .bind(user_id.as_str())
             .bind(provider)
             .bind(subject)

--- a/torii-storage-postgres/src/passkey.rs
+++ b/torii-storage-postgres/src/passkey.rs
@@ -18,7 +18,7 @@ impl PasskeyStorage for PostgresStorage {
         sqlx::query(
             r#"
             INSERT INTO passkeys (credential_id, user_id, public_key) 
-            VALUES ($1, $2::uuid, $3)
+            VALUES ($1, $2, $3)
             "#,
         )
         .bind(credential_id)
@@ -56,7 +56,7 @@ impl PasskeyStorage for PostgresStorage {
             r#"
             SELECT public_key 
             FROM passkeys 
-            WHERE user_id = $1::uuid
+            WHERE user_id = $1
             "#,
         )
         .bind(user_id.as_str())

--- a/torii-storage-postgres/src/passkey.rs
+++ b/torii-storage-postgres/src/passkey.rs
@@ -74,7 +74,7 @@ impl PasskeyStorage for PostgresStorage {
     ) -> Result<(), <Self as PasskeyStorage>::Error> {
         sqlx::query(
             r#"
-            INSERT INTO passkey_challenges (id, challenge, expires_at) 
+            INSERT INTO passkey_challenges (challenge_id, challenge, expires_at) 
             VALUES ($1, $2, $3)
             "#,
         )
@@ -95,7 +95,7 @@ impl PasskeyStorage for PostgresStorage {
             r#"
             SELECT challenge 
             FROM passkey_challenges 
-            WHERE id = $1 AND expires_at > $2
+            WHERE challenge_id = $1 AND expires_at > $2
             "#,
         )
         .bind(challenge_id)

--- a/torii-storage-postgres/src/password.rs
+++ b/torii-storage-postgres/src/password.rs
@@ -13,7 +13,7 @@ impl PasswordStorage for PostgresStorage {
         user_id: &UserId,
         hash: &str,
     ) -> Result<(), <Self as PasswordStorage>::Error> {
-        sqlx::query("UPDATE users SET password_hash = $1 WHERE id::text = $2")
+        sqlx::query("UPDATE users SET password_hash = $1 WHERE id = $2")
             .bind(hash)
             .bind(user_id.as_str())
             .execute(&self.pool)
@@ -26,7 +26,7 @@ impl PasswordStorage for PostgresStorage {
         &self,
         user_id: &UserId,
     ) -> Result<Option<String>, <Self as PasswordStorage>::Error> {
-        let result = sqlx::query_scalar("SELECT password_hash FROM users WHERE id::text = $1")
+        let result = sqlx::query_scalar("SELECT password_hash FROM users WHERE id = $1")
             .bind(user_id.as_str())
             .fetch_optional(&self.pool)
             .await

--- a/torii-storage-postgres/src/session.rs
+++ b/torii-storage-postgres/src/session.rs
@@ -52,7 +52,7 @@ impl SessionStorage for PostgresStorage {
     type Error = torii_core::Error;
 
     async fn create_session(&self, session: &Session) -> Result<Session, Self::Error> {
-        sqlx::query("INSERT INTO sessions (token, user_id, user_agent, ip_address, created_at, updated_at, expires_at) VALUES ($1, $2::uuid, $3, $4, $5, $6, $7)")
+        sqlx::query("INSERT INTO sessions (token, user_id, user_agent, ip_address, created_at, updated_at, expires_at) VALUES ($1, $2, $3, $4, $5, $6, $7)")
             .bind(session.token.as_str())
             .bind(session.user_id.as_str())
             .bind(&session.user_agent)
@@ -73,7 +73,7 @@ impl SessionStorage for PostgresStorage {
     async fn get_session(&self, token: &SessionToken) -> Result<Option<Session>, Self::Error> {
         let session = sqlx::query_as::<_, PostgresSession>(
             r#"
-            SELECT id, token, user_id::text, user_agent, ip_address, created_at, updated_at, expires_at
+            SELECT id, token, user_id, user_agent, ip_address, created_at, updated_at, expires_at
             FROM sessions
             WHERE token = $1
             "#,
@@ -116,7 +116,7 @@ impl SessionStorage for PostgresStorage {
     }
 
     async fn delete_sessions_for_user(&self, user_id: &UserId) -> Result<(), Self::Error> {
-        sqlx::query("DELETE FROM sessions WHERE user_id::text = $1")
+        sqlx::query("DELETE FROM sessions WHERE user_id = $1")
             .bind(user_id.as_str())
             .execute(&self.pool)
             .await

--- a/torii-storage-seaorm/src/migrations/m20250304_000001_create_user_table.rs
+++ b/torii-storage-seaorm/src/migrations/m20250304_000001_create_user_table.rs
@@ -5,7 +5,7 @@ use sea_orm::{
 };
 use sea_orm_migration::{
     MigrationTrait, SchemaManager,
-    schema::{pk_uuid, string, string_null, timestamp, timestamp_null},
+    schema::{string, string_null, timestamp, timestamp_null},
 };
 
 use super::Users;
@@ -21,7 +21,7 @@ impl MigrationTrait for CreateUsers {
                 Table::create()
                     .table(Users::Table)
                     .if_not_exists()
-                    .col(pk_uuid(Users::Id))
+                    .col(string(Users::Id).primary_key())
                     .col(string(Users::Email))
                     .col(string_null(Users::Name)) // Nullable since users may not have a name yet...
                     .col(string_null(Users::PasswordHash)) // Nullable since users may not have a password (i.e. OAuth, Passkey, Magic Link)

--- a/torii-storage-seaorm/src/session.rs
+++ b/torii-storage-seaorm/src/session.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter};
-use torii_core::session::SessionId;
+use torii_core::session::SessionToken;
 use torii_core::{Session, SessionStorage, UserId};
 
 use crate::SeaORMStorage;
@@ -10,7 +10,7 @@ use crate::entities::session;
 impl From<session::Model> for Session {
     fn from(value: session::Model) -> Self {
         Self {
-            token: SessionId::new(&value.token),
+            token: SessionToken::new(&value.token),
             user_id: UserId::new(&value.user_id),
             user_agent: value.user_agent.to_owned(),
             ip_address: value.ip_address.to_owned(),
@@ -45,7 +45,7 @@ impl SessionStorage for SeaORMStorage {
 
     async fn get_session(
         &self,
-        id: &SessionId,
+        id: &SessionToken,
     ) -> Result<Option<Session>, <Self as SessionStorage>::Error> {
         let session = session::Entity::find()
             .filter(session::Column::Token.eq(id.as_str()))
@@ -56,7 +56,10 @@ impl SessionStorage for SeaORMStorage {
         Ok(session)
     }
 
-    async fn delete_session(&self, id: &SessionId) -> Result<(), <Self as SessionStorage>::Error> {
+    async fn delete_session(
+        &self,
+        id: &SessionToken,
+    ) -> Result<(), <Self as SessionStorage>::Error> {
         session::Entity::delete_many()
             .filter(session::Column::Token.eq(id.as_str()))
             .exec(&self.pool)

--- a/torii-storage-sqlite/src/magic_link.rs
+++ b/torii-storage-sqlite/src/magic_link.rs
@@ -10,7 +10,7 @@ use crate::SqliteStorage;
 
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct SqliteMagicToken {
-    pub id: Option<String>,
+    pub id: Option<i64>,
     pub user_id: String,
     pub token: String,
     pub used_at: Option<i64>,

--- a/torii-storage-sqlite/src/migrations/mod.rs
+++ b/torii-storage-sqlite/src/migrations/mod.rs
@@ -194,7 +194,8 @@ impl Migration<Sqlite> for CreateSessionsTable {
         sqlx::query(
             r#"
             CREATE TABLE IF NOT EXISTS sessions (
-                id TEXT PRIMARY KEY,
+                id INTEGER PRIMARY KEY,
+                token TEXT NOT NULL,
                 user_id TEXT NOT NULL,
                 user_agent TEXT,
                 ip_address TEXT,
@@ -255,7 +256,8 @@ impl Migration<Sqlite> for CreateOAuthAccountsTable {
         sqlx::query(
             r#"
             CREATE TABLE IF NOT EXISTS oauth_state (
-                csrf_state TEXT PRIMARY KEY,
+                id INTEGER PRIMARY KEY,
+                csrf_state TEXT NOT NULL,
                 pkce_verifier TEXT NOT NULL,
                 expires_at INTEGER NOT NULL,
                 created_at INTEGER DEFAULT (unixepoch()),
@@ -298,7 +300,8 @@ impl Migration<Sqlite> for CreatePasskeysTable {
         sqlx::query(
             r#"
             CREATE TABLE IF NOT EXISTS passkeys (
-                id TEXT PRIMARY KEY,
+                id INTEGER PRIMARY KEY,
+                credential_id TEXT NOT NULL,
                 user_id TEXT NOT NULL,
                 public_key TEXT NOT NULL,
                 created_at INTEGER DEFAULT (unixepoch()),
@@ -341,11 +344,13 @@ impl Migration<Sqlite> for CreatePasskeyChallengesTable {
         sqlx::query(
             r#"
             CREATE TABLE IF NOT EXISTS passkey_challenges (
-                id TEXT PRIMARY KEY,
+                id INTEGER PRIMARY KEY,
+                challenge_id TEXT NOT NULL,
                 challenge TEXT NOT NULL,
                 expires_at INTEGER NOT NULL,
                 created_at INTEGER DEFAULT (unixepoch()),
-                updated_at INTEGER DEFAULT (unixepoch())
+                updated_at INTEGER DEFAULT (unixepoch()),
+                UNIQUE(challenge_id)
             );"#,
         )
         .execute(conn)
@@ -453,7 +458,7 @@ impl Migration<Sqlite> for CreateMagicLinksTable {
         sqlx::query(
             r#"
             CREATE TABLE IF NOT EXISTS magic_links (
-                id TEXT PRIMARY KEY,
+                id INTEGER PRIMARY KEY,
                 user_id TEXT NOT NULL,
                 token TEXT NOT NULL,
                 used_at INTEGER,

--- a/torii-storage-sqlite/src/oauth.rs
+++ b/torii-storage-sqlite/src/oauth.rs
@@ -7,6 +7,8 @@ use torii_core::{OAuthAccount, User, UserId};
 
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct SqliteOAuthAccount {
+    #[allow(dead_code)]
+    id: Option<i64>,
     user_id: String,
     provider: String,
     subject: String,
@@ -34,6 +36,7 @@ impl From<SqliteOAuthAccount> for OAuthAccount {
 impl From<OAuthAccount> for SqliteOAuthAccount {
     fn from(oauth_account: OAuthAccount) -> Self {
         SqliteOAuthAccount {
+            id: None,
             user_id: oauth_account.user_id.into_inner(),
             provider: oauth_account.provider,
             subject: oauth_account.subject,
@@ -58,7 +61,7 @@ impl OAuthStorage for SqliteStorage {
             r#"
             INSERT INTO oauth_accounts (user_id, provider, subject, created_at, updated_at)
             VALUES (?, ?, ?, ?, ?)
-            RETURNING user_id, provider, subject, created_at, updated_at
+            RETURNING id, user_id, provider, subject, created_at, updated_at
             "#,
         )
         .bind(user_id.as_str())
@@ -111,7 +114,7 @@ impl OAuthStorage for SqliteStorage {
     ) -> Result<Option<OAuthAccount>, <Self as OAuthStorage>::Error> {
         let oauth_account = sqlx::query_as::<_, SqliteOAuthAccount>(
             r#"
-            SELECT user_id, provider, subject, created_at, updated_at
+            SELECT id, user_id, provider, subject, created_at, updated_at
             FROM oauth_accounts
             WHERE provider = ? AND subject = ?
             "#,

--- a/torii-storage-sqlite/src/passkey.rs
+++ b/torii-storage-sqlite/src/passkey.rs
@@ -17,7 +17,7 @@ impl PasskeyStorage for SqliteStorage {
     ) -> Result<(), <Self as PasskeyStorage>::Error> {
         sqlx::query(
             r#"
-            INSERT INTO passkeys (id, user_id, public_key) 
+            INSERT INTO passkeys (credential_id, user_id, public_key) 
             VALUES (?, ?, ?)
             "#,
         )
@@ -38,7 +38,7 @@ impl PasskeyStorage for SqliteStorage {
             r#"
             SELECT public_key 
             FROM passkeys 
-            WHERE id = ?
+            WHERE credential_id = ?
             "#,
         )
         .bind(credential_id)
@@ -74,7 +74,7 @@ impl PasskeyStorage for SqliteStorage {
     ) -> Result<(), <Self as PasskeyStorage>::Error> {
         sqlx::query(
             r#"
-            INSERT INTO passkey_challenges (id, challenge, expires_at) 
+            INSERT INTO passkey_challenges (challenge_id, challenge, expires_at) 
             VALUES (?, ?, ?)
             "#,
         )
@@ -95,7 +95,7 @@ impl PasskeyStorage for SqliteStorage {
             r#"
             SELECT challenge 
             FROM passkey_challenges 
-            WHERE id = ? AND expires_at > ?
+            WHERE challenge_id = ? AND expires_at > ?
             "#,
         )
         .bind(challenge_id)

--- a/torii/src/lib.rs
+++ b/torii/src/lib.rs
@@ -59,7 +59,7 @@ use torii_core::{
 
 /// Re-export core types
 pub use torii_core::{
-    session::{Session, SessionId},
+    session::{Session, SessionToken},
     user::{User, UserId},
 };
 
@@ -186,7 +186,7 @@ where
     /// # Returns
     ///
     /// Returns the session if found, otherwise `None`
-    pub async fn get_session(&self, session_id: &SessionId) -> Result<Session, ToriiError> {
+    pub async fn get_session(&self, session_id: &SessionToken) -> Result<Session, ToriiError> {
         let session = self
             .session_manager
             .get_session(session_id)


### PR DESCRIPTION
This aligns the schemas on UserId being an opaque string. It may or may not always be a UUID so we shouldn't type it as such. 

This opens the door for doing things like prefixed IDs

https://clerk.com/blog/generating-sortable-stripe-like-ids-with-segment-ksuids