### PR TITLE
refactor(passkey): redesign WebAuthn API for improved type safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SessionToken` type now supports both simple UUID tokens and JWT tokens.
 - Added `JwtConfig` for configuring JWT session parameters.
 
+#### `torii-auth-passkey`
+
+- Completely redesigned the passkey authentication API for improved type safety and usability:
+  - Added a `PasskeyAuthPlugin` trait to define standardized authentication methods
+  - Replaced string and JSON value parameters with proper strongly-typed structures:
+    - `PasskeyRegistrationRequest` and `PasskeyRegistrationCompletion`
+    - `PasskeyLoginRequest` and `PasskeyLoginCompletion`
+    - `ChallengeId` type for better type safety
+  - Created separate public-facing credential types:
+    - `PasskeyCredentialCreationOptions`
+    - `PasskeyCredentialRequestOptions`
+  - Enhanced error handling with detailed context information using `PasskeyErrorContext`
+  - **BREAKING CHANGE**: Removed the deprecated `PasskeyChallenge` structure and the old method signatures
+  - Updated the `torii` integration to use the new API with both structured types and convenient alternatives
+
 #### `torii`
 
 - Login methods now accept an optional user agent and ip address parameter which will be stored with the session in the database.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,18 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Support for both RS256 (RSA+SHA256) and HS256 (HMAC+SHA256) algorithms:
     - RS256: Uses asymmetric cryptography with separate signing and verification keys
     - HS256: Uses symmetric cryptography with a single secret key
+- Updated passkey example to use SimpleWebAuthn browser library from the CDN for improved WebAuthn support
 
 ### Changed
 
 #### `torii-core`
 
 - `SessionStorage::get_session` now returns a `Result<Option<Session>, Error>` instead of `Result<Session, Error>`. This reverts the change from `0.2.3`.
-- `SessionToken` type now supports both simple UUID tokens and JWT tokens.
+- `SessionToken` type now supports both opaque tokens and JWT tokens.
 - Added `JwtConfig` for configuring JWT session parameters.
 
 #### `torii-auth-passkey`
 
-- Completely redesigned the passkey authentication API for improved type safety and usability:
+- **BREAKING CHANGE**: Completely redesigned the passkey authentication API for improved type safety and usability:
   - Added a `PasskeyAuthPlugin` trait to define standardized authentication methods
   - Replaced string and JSON value parameters with proper strongly-typed structures:
     - `PasskeyRegistrationRequest` and `PasskeyRegistrationCompletion`
@@ -38,7 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `PasskeyCredentialCreationOptions`
     - `PasskeyCredentialRequestOptions`
   - Enhanced error handling with detailed context information using `PasskeyErrorContext`
-  - **BREAKING CHANGE**: Removed the deprecated `PasskeyChallenge` structure and the old method signatures
   - Updated the `torii` integration to use the new API with both structured types and convenient alternatives
 
 #### `torii`

--- a/torii-auth-passkey/Cargo.toml
+++ b/torii-auth-passkey/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 [dependencies]
 torii-core = { path = "../torii-core", version = "0.2.2" }
 
+async-trait.workspace = true
 chrono.workspace = true
 webauthn-rs = { version = "0.5.1", features = [
     "danger-allow-state-serialisation",
@@ -17,6 +18,7 @@ serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
+uuid = { workspace = true, features = ["v4", "serde"] }
 
 [dev-dependencies]
 axum = { version = "0.8", features = ["macros"] }

--- a/torii-auth-passkey/examples/passkey.rs
+++ b/torii-auth-passkey/examples/passkey.rs
@@ -9,7 +9,7 @@ use axum::{
     routing::{get, post},
 };
 use axum_extra::extract::{CookieJar, cookie::Cookie};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_json::json;
 use sqlx::{Pool, Sqlite};
 use torii_auth_passkey::{
@@ -74,6 +74,7 @@ async fn begin_registration_handler(
 #[derive(Debug, Deserialize)]
 struct RegistrationCompletionRequest {
     email: String,
+    #[allow(dead_code)]
     challenge_id: Option<String>,
     response: serde_json::Value,
 }
@@ -132,11 +133,11 @@ async fn finish_registration_handler(
     .await
     .map_err(|e| {
         tracing::error!("Failed to complete registration: {:?}", e);
-        return (
+        (
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("Failed to complete registration: {}", e),
         )
-            .into_response();
+            .into_response()
     })
     .unwrap();
 
@@ -258,6 +259,7 @@ async fn begin_login_handler(
 #[derive(Debug, Deserialize)]
 struct LoginCompletionRequest {
     email: String,
+    #[allow(dead_code)]
     challenge_id: Option<String>,
     response: serde_json::Value,
 }

--- a/torii-auth-passkey/src/lib.rs
+++ b/torii-auth-passkey/src/lib.rs
@@ -13,47 +13,228 @@
 //! - Challenge-response based authentication flow
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use torii_core::error::{AuthError, PluginError, StorageError};
 use torii_core::storage::PasskeyStorage;
-use torii_core::{Error, Plugin, User, UserId};
+use torii_core::{Error, Plugin, User};
+use uuid::Uuid;
 use webauthn_rs::prelude::*;
+
+/// Unique identifier for a passkey challenge
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ChallengeId(String);
+
+impl ChallengeId {
+    /// Create a new challenge ID from a string
+    pub fn new(id: String) -> Self {
+        Self(id)
+    }
+
+    /// Generate a new random challenge ID
+    pub fn new_random() -> Self {
+        Self(Uuid::new_v4().to_string())
+    }
+
+    /// Get the string representation of the challenge ID
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for ChallengeId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for ChallengeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Public-facing credential creation options for registering a new passkey
+///
+/// This is what is returned to the client when starting a passkey registration.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PasskeyCredentialCreationOptions {
+    /// The unique ID of the challenge
+    pub challenge_id: ChallengeId,
+    /// WebAuthn credential creation options to be passed to the client
+    #[serde(rename = "publicKey")]
+    pub options: serde_json::Value,
+}
+
+/// Public-facing credential request options for authenticating with a passkey
+///
+/// This is what is returned to the client when starting a passkey login.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PasskeyCredentialRequestOptions {
+    /// The unique ID of the challenge
+    pub challenge_id: ChallengeId,
+    /// WebAuthn credential request options to be passed to the client
+    #[serde(rename = "publicKey")]
+    pub options: serde_json::Value,
+}
+
+/// A request to register a new passkey
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PasskeyRegistrationRequest {
+    /// The email address of the user
+    pub email: String,
+}
+
+/// Client response to complete a passkey registration
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PasskeyRegistrationCompletion {
+    /// The email address of the user
+    pub email: String,
+    /// The challenge ID from the initial registration request
+    pub challenge_id: ChallengeId,
+    /// The client's credential response
+    pub response: RegisterPublicKeyCredential,
+}
+
+/// A request to authenticate with a passkey
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PasskeyLoginRequest {
+    /// The email address of the user
+    pub email: String,
+}
+
+/// Client response to complete a passkey login
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PasskeyLoginCompletion {
+    /// The email address of the user
+    pub email: String,
+    /// The challenge ID from the initial login request
+    pub challenge_id: ChallengeId,
+    /// The client's credential response
+    pub response: PublicKeyCredential,
+}
+
+/// Context for error messages to provide better diagnostics
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PasskeyErrorContext {
+    /// Error occurred during registration
+    Registration,
+    /// Error occurred during authentication
+    Authentication,
+    /// Error occurred during challenge processing
+    Challenge,
+    /// Error related to passkey storage
+    Storage,
+}
+
+impl std::fmt::Display for PasskeyErrorContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Registration => write!(f, "registration"),
+            Self::Authentication => write!(f, "authentication"),
+            Self::Challenge => write!(f, "challenge"),
+            Self::Storage => write!(f, "storage"),
+        }
+    }
+}
 
 #[derive(Debug, Error)]
 pub enum PasskeyError {
-    #[error("Webauthn error: {0}")]
-    Webauthn(#[from] WebauthnError),
+    #[error("[{context}] Webauthn error: {source}")]
+    Webauthn {
+        context: PasskeyErrorContext,
+        #[source]
+        source: WebauthnError,
+    },
 
-    #[error("Invalid credentials")]
-    InvalidCredentials,
-    #[error("Passkey exists")]
-    PasskeyExists,
-    #[error("Invalid challenge")]
-    InvalidChallenge,
-    #[error("Invalid challenge response")]
-    InvalidChallengeResponse,
-    #[error("Invalid challenge response format")]
-    InvalidChallengeResponseFormat,
+    #[error("[{context}] Invalid credentials")]
+    InvalidCredentials { context: PasskeyErrorContext },
 
-    #[error("Storage error: {0}")]
-    StorageError(String),
+    #[error("[{context}] Passkey already exists")]
+    PasskeyExists { context: PasskeyErrorContext },
+
+    #[error("[{context}] Invalid challenge: {message}")]
+    InvalidChallenge {
+        context: PasskeyErrorContext,
+        message: String,
+    },
+
+    #[error("[{context}] Invalid challenge response: {message}")]
+    InvalidChallengeResponse {
+        context: PasskeyErrorContext,
+        message: String,
+    },
+
+    #[error("[{context}] Storage error: {message}")]
+    StorageError {
+        context: PasskeyErrorContext,
+        message: String,
+    },
+
+    #[error("[{context}] User not found")]
+    UserNotFound { context: PasskeyErrorContext },
+
+    #[error("[{context}] Serialization error: {message}")]
+    SerializationError {
+        context: PasskeyErrorContext,
+        message: String,
+    },
 }
 
 impl From<PasskeyError> for Error {
     fn from(error: PasskeyError) -> Self {
         match error {
-            PasskeyError::Webauthn(e) => Error::Plugin(PluginError::OperationFailed(e.to_string())),
-            PasskeyError::InvalidCredentials => Error::Auth(AuthError::InvalidCredentials),
-            PasskeyError::PasskeyExists => Error::Auth(AuthError::UserAlreadyExists),
-            PasskeyError::InvalidChallenge => Error::Auth(AuthError::InvalidCredentials),
-            PasskeyError::InvalidChallengeResponse => Error::Auth(AuthError::InvalidCredentials),
-            PasskeyError::InvalidChallengeResponseFormat => {
+            PasskeyError::Webauthn { source, .. } => {
+                Error::Plugin(PluginError::OperationFailed(source.to_string()))
+            }
+            PasskeyError::InvalidCredentials { .. } => Error::Auth(AuthError::InvalidCredentials),
+            PasskeyError::PasskeyExists { .. } => Error::Auth(AuthError::UserAlreadyExists),
+            PasskeyError::InvalidChallenge { .. } => Error::Auth(AuthError::InvalidCredentials),
+            PasskeyError::InvalidChallengeResponse { .. } => {
                 Error::Auth(AuthError::InvalidCredentials)
             }
-            PasskeyError::StorageError(e) => Error::Storage(StorageError::Database(e)),
+            PasskeyError::StorageError { message, .. } => {
+                Error::Storage(StorageError::Database(message))
+            }
+            PasskeyError::UserNotFound { .. } => Error::Auth(AuthError::UserNotFound),
+            PasskeyError::SerializationError { message, .. } => {
+                Error::Plugin(PluginError::OperationFailed(message))
+            }
         }
     }
+}
+
+/// Trait defining passkey authentication functionality
+#[async_trait]
+pub trait PasskeyAuthPlugin: Plugin {
+    /// Start a passkey registration and return the challenge to the client.
+    /// The challenge is stored in the database for verification.
+    async fn start_registration(
+        &self,
+        request: &PasskeyRegistrationRequest,
+    ) -> Result<PasskeyCredentialCreationOptions, PasskeyError>;
+
+    /// Complete a passkey registration and create a user in the user storage.
+    /// Returns the user if the registration is successful.
+    async fn complete_registration(
+        &self,
+        completion: &PasskeyRegistrationCompletion,
+    ) -> Result<User, PasskeyError>;
+
+    /// Start a passkey login and return the challenge to the client.
+    /// The challenge is stored in the database for verification.
+    async fn start_login(
+        &self,
+        request: &PasskeyLoginRequest,
+    ) -> Result<PasskeyCredentialRequestOptions, PasskeyError>;
+
+    /// Complete a passkey login.
+    /// Returns the user if the login is successful.
+    async fn complete_login(
+        &self,
+        completion: &PasskeyLoginCompletion,
+    ) -> Result<User, PasskeyError>;
 }
 
 /// A plugin for managing passkey authentication.
@@ -64,43 +245,6 @@ impl From<PasskeyError> for Error {
 pub struct PasskeyPlugin<U: PasskeyStorage> {
     webauthn: Webauthn,
     user_storage: Arc<U>,
-}
-
-/// A challenge for a passkey authentication process.
-///
-/// This struct represents a challenge for a passkey authentication process. It contains the user ID,
-/// the challenge ID, and the challenge response.
-///
-/// # Fields
-/// - `user_id`: The ID of the user that the challenge belongs to.
-/// - `challenge_id`: The ID of the challenge.
-/// - `challenge`: The challenge response. This is typically a JSON object containing the challenge
-///   response from the WebAuthn library.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct PasskeyChallenge {
-    user_id: UserId,
-    challenge_id: String,
-    challenge: serde_json::Value,
-}
-
-impl PasskeyChallenge {
-    pub fn new(user_id: UserId, challenge_id: String, challenge: serde_json::Value) -> Self {
-        Self {
-            user_id,
-            challenge_id,
-            challenge,
-        }
-    }
-
-    /// Get the ID of the challenge.
-    pub fn challenge_id(&self) -> &String {
-        &self.challenge_id
-    }
-
-    /// Get the challenge response.
-    pub fn challenge(&self) -> &serde_json::Value {
-        &self.challenge
-    }
 }
 
 impl<U: PasskeyStorage> PasskeyPlugin<U> {
@@ -114,233 +258,285 @@ impl<U: PasskeyStorage> PasskeyPlugin<U> {
             user_storage,
         }
     }
+}
 
-    /// Start a passkey registration and return the challenge to the client.
-    /// The challenge is stored in the database for verification.
-    /// Returns a challenge that should be sent to the client.
-    pub async fn start_registration(&self, email: &str) -> Result<PasskeyChallenge, PasskeyError> {
-        let challenge_id = Uuid::new_v4();
+#[async_trait]
+impl<U: PasskeyStorage> PasskeyAuthPlugin for PasskeyPlugin<U> {
+    async fn start_registration(
+        &self,
+        request: &PasskeyRegistrationRequest,
+    ) -> Result<PasskeyCredentialCreationOptions, PasskeyError> {
+        let challenge_id = ChallengeId::new_random();
+
         // CCR is sent to the client, SKR is stored in the database for verification
         // We (currently) have no use for the user_unique_id after this point, but the API requires it
         // https://github.com/kanidm/webauthn-rs/issues/277
         let (ccr, skr) = self
             .webauthn
-            .start_passkey_registration(Uuid::new_v4(), email, email, None)
-            .expect("Failed to start registration.");
+            .start_passkey_registration(Uuid::new_v4(), &request.email, &request.email, None)
+            .map_err(|e| PasskeyError::Webauthn {
+                context: PasskeyErrorContext::Registration,
+                source: e,
+            })?;
 
+        // Serialize and store the challenge
+        let skr_json =
+            serde_json::to_string(&skr).map_err(|e| PasskeyError::SerializationError {
+                context: PasskeyErrorContext::Registration,
+                message: e.to_string(),
+            })?;
+
+        // Store the challenge with expiration
         self.user_storage
             .set_passkey_challenge(
-                &challenge_id.to_string(),
-                &serde_json::to_string(&skr).unwrap_or_else(|e| {
-                    tracing::error!(error = ?e, "Failed to serialize challenge");
-                    "".to_string()
-                }),
+                challenge_id.as_str(),
+                &skr_json,
                 chrono::Duration::minutes(5),
             )
             .await
-            .map_err(|e| {
-                tracing::error!(error = ?e, "Failed to set passkey challenge");
-                PasskeyError::StorageError(e.to_string())
+            .map_err(|e| PasskeyError::StorageError {
+                context: PasskeyErrorContext::Registration,
+                message: e.to_string(),
             })?;
 
-        Ok(PasskeyChallenge::new(
-            UserId::new_random(),
-            challenge_id.to_string(),
-            serde_json::to_value(&ccr).unwrap_or_else(|e| {
-                tracing::error!(error = ?e, "Failed to serialize challenge");
-                serde_json::Value::Null
-            }),
-        ))
+        // Serialize the client options
+        let options_json =
+            serde_json::to_value(&ccr).map_err(|e| PasskeyError::SerializationError {
+                context: PasskeyErrorContext::Registration,
+                message: e.to_string(),
+            })?;
+
+        Ok(PasskeyCredentialCreationOptions {
+            challenge_id,
+            options: options_json,
+        })
     }
 
-    /// Complete a passkey registration and create a user in the user storage.
-    /// Returns the user if the registration is successful.
-    pub async fn complete_registration(
+    async fn complete_registration(
         &self,
-        email: &str,
-        challenge_id: &str,
-        challenge_response: &serde_json::Value,
+        completion: &PasskeyRegistrationCompletion,
     ) -> Result<User, PasskeyError> {
-        let challenge_response: RegisterPublicKeyCredential =
-            serde_json::from_value::<RegisterPublicKeyCredential>(challenge_response.clone())
-                .map_err(|e| {
-                    tracing::error!(error = ?e, "Failed to deserialize challenge response");
-                    PasskeyError::InvalidChallengeResponseFormat
-                })?;
-
         // Check if the passkey already exists
         let passkey_exists = self
             .user_storage
-            .get_passkey_by_credential_id(&challenge_response.id)
+            .get_passkey_by_credential_id(&completion.response.id)
             .await
-            .map_err(|e| {
-                tracing::error!(error = ?e, "Failed to get passkey by credential id");
-                PasskeyError::StorageError(e.to_string())
+            .map_err(|e| PasskeyError::StorageError {
+                context: PasskeyErrorContext::Registration,
+                message: e.to_string(),
             })?;
 
         if passkey_exists.is_some() {
-            return Err(PasskeyError::PasskeyExists);
+            return Err(PasskeyError::PasskeyExists {
+                context: PasskeyErrorContext::Registration,
+            });
         }
 
         // Get the challenge from the database
         let passkey_challenge = self
             .user_storage
-            .get_passkey_challenge(challenge_id)
+            .get_passkey_challenge(completion.challenge_id.as_str())
             .await
-            .map_err(|e| {
-                tracing::error!(error = ?e, "Failed to get passkey challenge");
-                PasskeyError::StorageError(e.to_string())
+            .map_err(|e| PasskeyError::StorageError {
+                context: PasskeyErrorContext::Challenge,
+                message: e.to_string(),
             })?
-            .ok_or(PasskeyError::InvalidChallenge)?;
+            .ok_or(PasskeyError::InvalidChallenge {
+                context: PasskeyErrorContext::Registration,
+                message: "Challenge not found or expired".to_string(),
+            })?;
 
-        // Deserialize the challenge into a PasskeyRegistration
-        let passkey_challenge: PasskeyRegistration =
-            serde_json::from_str::<PasskeyRegistration>(&passkey_challenge).map_err(|e| {
-                tracing::error!(error = ?e, "Failed to deserialize passkey challenge");
-                PasskeyError::InvalidChallengeResponseFormat
+        // Deserialize the challenge
+        let passkey_challenge: PasskeyRegistration = serde_json::from_str(&passkey_challenge)
+            .map_err(|e| PasskeyError::SerializationError {
+                context: PasskeyErrorContext::Challenge,
+                message: format!("Failed to deserialize challenge: {}", e),
             })?;
 
         // Finish the passkey registration
         let passkey = self
             .webauthn
-            .finish_passkey_registration(&challenge_response, &passkey_challenge)
-            .expect("Failed to complete registration.");
+            .finish_passkey_registration(&completion.response, &passkey_challenge)
+            .map_err(|e| PasskeyError::Webauthn {
+                context: PasskeyErrorContext::Registration,
+                source: e,
+            })?;
 
         // Get or create the user
         let user = self
             .user_storage
-            .get_or_create_user_by_email(email)
+            .get_or_create_user_by_email(&completion.email)
             .await
-            .map_err(|e| {
-                tracing::error!(error = ?e, "Failed to get or create user by email");
-                PasskeyError::StorageError(e.to_string())
+            .map_err(|e| PasskeyError::StorageError {
+                context: PasskeyErrorContext::Registration,
+                message: e.to_string(),
             })?;
+
+        // Serialize the passkey
+        let passkey_json =
+            serde_json::to_string(&passkey).map_err(|e| PasskeyError::SerializationError {
+                context: PasskeyErrorContext::Registration,
+                message: e.to_string(),
+            })?;
+
+        let cred_id = serde_json::to_string(&passkey.cred_id()).map_err(|e| {
+            PasskeyError::SerializationError {
+                context: PasskeyErrorContext::Registration,
+                message: e.to_string(),
+            }
+        })?;
 
         // Add the passkey to the user
         self.user_storage
-            .add_passkey(
-                &user.id,
-                &serde_json::to_string(&passkey.cred_id()).unwrap(),
-                &serde_json::to_string(&passkey).unwrap(),
-            )
+            .add_passkey(&user.id, &cred_id, &passkey_json)
             .await
-            .map_err(|e| {
-                tracing::error!(error = ?e, "Failed to add passkey");
-                PasskeyError::StorageError(e.to_string())
+            .map_err(|e| PasskeyError::StorageError {
+                context: PasskeyErrorContext::Registration,
+                message: e.to_string(),
             })?;
 
         Ok(user)
     }
 
-    /// Start a passkey login and return the challenge to the client.
-    /// The challenge is stored in the database for verification.
-    /// Returns a challenge that should be sent to the client.
-    pub async fn start_login(&self, email: &str) -> Result<PasskeyChallenge, PasskeyError> {
+    async fn start_login(
+        &self,
+        request: &PasskeyLoginRequest,
+    ) -> Result<PasskeyCredentialRequestOptions, PasskeyError> {
+        // Get the user by email
         let user = self
             .user_storage
-            .get_user_by_email(email)
+            .get_user_by_email(&request.email)
             .await
-            .map_err(|e| {
-                tracing::error!(error = ?e, "Failed to get user by email");
-                PasskeyError::StorageError(e.to_string())
+            .map_err(|e| PasskeyError::StorageError {
+                context: PasskeyErrorContext::Authentication,
+                message: e.to_string(),
             })?
-            .ok_or(PasskeyError::InvalidCredentials)?;
+            .ok_or(PasskeyError::UserNotFound {
+                context: PasskeyErrorContext::Authentication,
+            })?;
 
         // Get the passkeys for the user
         let passkey_credentials = self
             .user_storage
             .get_passkeys(&user.id)
             .await
-            .map_err(|e| {
-                tracing::error!(error = ?e, "Failed to get passkeys");
-                PasskeyError::StorageError(e.to_string())
+            .map_err(|e| PasskeyError::StorageError {
+                context: PasskeyErrorContext::Authentication,
+                message: e.to_string(),
             })?;
+
+        if passkey_credentials.is_empty() {
+            return Err(PasskeyError::InvalidCredentials {
+                context: PasskeyErrorContext::Authentication,
+            });
+        }
 
         // Deserialize the passkeys into a vector of Passkey
         let allowed_credentials = passkey_credentials
             .iter()
-            .map(|cred| serde_json::from_str::<Passkey>(cred).unwrap())
+            .filter_map(|cred| match serde_json::from_str::<Passkey>(cred) {
+                Ok(pk) => Some(pk),
+                Err(e) => {
+                    tracing::error!(error = ?e, "Failed to deserialize passkey");
+                    None
+                }
+            })
             .collect::<Vec<_>>();
 
+        if allowed_credentials.is_empty() {
+            return Err(PasskeyError::InvalidCredentials {
+                context: PasskeyErrorContext::Authentication,
+            });
+        }
+
         // Start the passkey login
-        let challenge_id = Uuid::new_v4();
+        let challenge_id = ChallengeId::new_random();
         let (rcr, rak) = self
             .webauthn
             .start_passkey_authentication(&allowed_credentials)
-            .expect("Failed to start login.");
+            .map_err(|e| PasskeyError::Webauthn {
+                context: PasskeyErrorContext::Authentication,
+                source: e,
+            })?;
+
+        // Serialize the authentication challenge
+        let rak_json =
+            serde_json::to_string(&rak).map_err(|e| PasskeyError::SerializationError {
+                context: PasskeyErrorContext::Authentication,
+                message: e.to_string(),
+            })?;
 
         // Store the challenge in the database
         self.user_storage
             .set_passkey_challenge(
-                &challenge_id.to_string(),
-                &serde_json::to_string(&rak).unwrap(),
+                challenge_id.as_str(),
+                &rak_json,
                 chrono::Duration::minutes(5),
             )
             .await
-            .map_err(|e| {
-                tracing::error!(error = ?e, "Failed to set passkey challenge");
-                PasskeyError::StorageError(e.to_string())
+            .map_err(|e| PasskeyError::StorageError {
+                context: PasskeyErrorContext::Authentication,
+                message: e.to_string(),
+            })?;
+
+        // Serialize the client options
+        let options_json =
+            serde_json::to_value(&rcr).map_err(|e| PasskeyError::SerializationError {
+                context: PasskeyErrorContext::Authentication,
+                message: e.to_string(),
             })?;
 
         // Return the challenge
-        Ok(PasskeyChallenge::new(
-            user.id,
-            challenge_id.to_string(),
-            serde_json::to_value(&rcr).unwrap(),
-        ))
+        Ok(PasskeyCredentialRequestOptions {
+            challenge_id,
+            options: options_json,
+        })
     }
 
-    /// Complete a passkey login.
-    /// Returns the user if the login is successful.
-    pub async fn complete_login(
+    async fn complete_login(
         &self,
-        email: &str,
-        challenge_id: &str,
-        challenge_response: &serde_json::Value,
+        completion: &PasskeyLoginCompletion,
     ) -> Result<User, PasskeyError> {
         // Get the user by email
         let user = self
             .user_storage
-            .get_user_by_email(email)
+            .get_user_by_email(&completion.email)
             .await
-            .map_err(|e| {
-                tracing::error!(error = ?e, "Failed to get user by email");
-                PasskeyError::StorageError(e.to_string())
+            .map_err(|e| PasskeyError::StorageError {
+                context: PasskeyErrorContext::Authentication,
+                message: e.to_string(),
             })?
-            .ok_or(PasskeyError::InvalidCredentials)?;
+            .ok_or(PasskeyError::UserNotFound {
+                context: PasskeyErrorContext::Authentication,
+            })?;
 
         // Get the challenge from the database
         let passkey_challenge = self
             .user_storage
-            .get_passkey_challenge(challenge_id)
+            .get_passkey_challenge(completion.challenge_id.as_str())
             .await
-            .map_err(|e| {
-                tracing::error!(error = ?e, "Failed to get passkey challenge");
-                PasskeyError::StorageError(e.to_string())
+            .map_err(|e| PasskeyError::StorageError {
+                context: PasskeyErrorContext::Challenge,
+                message: e.to_string(),
             })?
-            .ok_or(PasskeyError::InvalidChallenge)?;
+            .ok_or(PasskeyError::InvalidChallenge {
+                context: PasskeyErrorContext::Authentication,
+                message: "Challenge not found or expired".to_string(),
+            })?;
 
-        // Deserialize the challenge into a PasskeyAuthentication
-        let passkey_challenge = serde_json::from_str::<PasskeyAuthentication>(&passkey_challenge)
-            .map_err(|e| {
-            tracing::error!(error = ?e, "Failed to deserialize passkey challenge");
-            PasskeyError::InvalidChallengeResponseFormat
-        })?;
-
-        // Deserialize the challenge response into a PublicKeyCredential
-        let challenge_response: PublicKeyCredential =
-            serde_json::from_value(challenge_response.clone()).map_err(|e| {
-                tracing::error!(error = ?e, "Failed to deserialize challenge response");
-                PasskeyError::InvalidChallengeResponseFormat
+        // Deserialize the challenge
+        let passkey_challenge: PasskeyAuthentication = serde_json::from_str(&passkey_challenge)
+            .map_err(|e| PasskeyError::SerializationError {
+                context: PasskeyErrorContext::Challenge,
+                message: format!("Failed to deserialize challenge: {}", e),
             })?;
 
         // Finish the passkey login
-        let _ = self
-            .webauthn
-            .finish_passkey_authentication(&challenge_response, &passkey_challenge)
-            .map_err(|e| {
-                tracing::error!(error = ?e, "Failed to complete login");
-                PasskeyError::InvalidCredentials
+        self.webauthn
+            .finish_passkey_authentication(&completion.response, &passkey_challenge)
+            .map_err(|e| PasskeyError::Webauthn {
+                context: PasskeyErrorContext::Authentication,
+                source: e,
             })?;
 
         Ok(user)

--- a/torii/tests/magic_link.rs
+++ b/torii/tests/magic_link.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use torii::{MagicToken, SqliteStorage, Torii};
+use torii::{SqliteStorage, Torii};
 
 #[cfg(all(feature = "magic-link", feature = "sqlite"))]
 #[tokio::test]
@@ -17,9 +17,9 @@ async fn test_magic_link_auth() {
     let magic_token = torii.generate_magic_token(email).await.unwrap();
 
     // Verify the token contains expected data
-    assert_eq!(magic_token.token.is_empty(), false);
+    assert!(!magic_token.token.is_empty());
     assert!(magic_token.token.len() > 32); // Should be a reasonably long token
-    assert_eq!(magic_token.used(), false); // Token should not be used yet
+    assert!(!magic_token.used()); // Token should not be used yet
     assert!(magic_token.expires_at > chrono::Utc::now()); // Should expire in the future
 
     // Verify the magic token


### PR DESCRIPTION
This commit introduces a completely redesigned WebAuthn API for the passkey authentication plugin, focusing on type safety and improved developer experience:

- Add a `PasskeyAuthPlugin` trait to define standardized authentication methods
- Replace string and JSON value parameters with strongly-typed structures:
  - `PasskeyRegistrationRequest` and `PasskeyRegistrationCompletion`
  - `PasskeyLoginRequest` and `PasskeyLoginCompletion`
  - `ChallengeId` type for better type safety
- Create separate public-facing credential types:
  - `PasskeyCredentialCreationOptions`
  - `PasskeyCredentialRequestOptions`
- Enhance error handling with detailed context using `PasskeyErrorContext`
- Remove deprecated methods and structures
- Update the `torii` integration to use the new API
- Provide both structured types and convenience methods
- Fix WebAuthn example to work with the new API

BREAKING CHANGE: This removes the deprecated `PasskeyChallenge` structure and the old method signatures, requiring clients to update to the new API.

🤖 Generated with [Claude Code](https://claude.ai/code)