### PR TITLE
Add User Info on code exchange

### DIFF
--- a/torii-auth-oauth/examples/github/github.rs
+++ b/torii-auth-oauth/examples/github/github.rs
@@ -60,7 +60,7 @@ async fn callback_handler(
         .get_plugin::<OAuthPlugin<DefaultUserManager<SqliteStorage>, SqliteStorage>>("github")
         .unwrap();
 
-    let user = plugin
+    let (user, _) = plugin
         .exchange_code(params.code.to_string(), csrf_state.to_string())
         .await
         .unwrap();

--- a/torii-auth-oauth/examples/google/google.rs
+++ b/torii-auth-oauth/examples/google/google.rs
@@ -60,7 +60,7 @@ async fn callback_handler(
         .get_plugin::<OAuthPlugin<DefaultUserManager<SqliteStorage>, SqliteStorage>>("google")
         .unwrap();
 
-    let user = plugin
+    let (user, _) = plugin
         .exchange_code(params.code.to_string(), csrf_state.to_string())
         .await
         .unwrap();

--- a/torii-auth-oauth/src/lib.rs
+++ b/torii-auth-oauth/src/lib.rs
@@ -285,7 +285,7 @@ where
     ///
     /// # Returns
     /// Returns a [`User`] struct containing the user's information.
-    pub async fn exchange_code(&self, code: String, csrf_state: String) -> Result<User, Error> {
+    pub async fn exchange_code(&self, code: String, csrf_state: String) -> Result<(User, UserInfo), Error> {
         let pkce_verifier = self
             .oauth_storage
             .get_pkce_verifier(&csrf_state)
@@ -338,7 +338,7 @@ where
             .await
             .map_err(|_| Error::Auth(AuthError::InvalidCredentials))?;
 
-        Ok(user)
+        Ok((user, user_info))
     }
 
     async fn emit_event(&self, event: &Event) -> Result<(), Error> {

--- a/torii/src/lib.rs
+++ b/torii/src/lib.rs
@@ -749,7 +749,7 @@ where
             .get_plugin::<OAuthPlugin<DefaultUserManager<US>, US>>(provider)
             .ok_or_else(|| ToriiError::PluginNotFound(provider.to_string()))?;
 
-        let user = oauth_plugin
+        let (user, _) = oauth_plugin
             .exchange_code(code.to_string(), csrf_state.to_string())
             .await
             .map_err(|e| ToriiError::AuthError(e.to_string()))?;


### PR DESCRIPTION
User struct is very limited to email , I wanted to extend so developer can also use other returned attribute from the oauth provider as needed