### PR TITLE
fix(#51): re-export JwtConfig in main crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `JwtConfig` is now re-exported for use in `torii` crate.
+
+## [0.3.0] - 2025-06-26
+
+### Added
+
 - Added a new crate, `torii-storage-seaorm`, which is a storage backend for the torii authentication ecosystem that uses SeaORM to target SQLite, Postgres, and MySQL.
 - Added JWT-based session support with configurable expiry time.
   - `JwtSessionManager`: A session manager that uses JWTs to store session data without requiring database lookup.

--- a/torii-auth-magic-link/examples/magic-link.rs
+++ b/torii-auth-magic-link/examples/magic-link.rs
@@ -95,11 +95,10 @@ async fn generate_magic_link_handler(
                 <div style="text-align: center;">
                     <p>For demonstration only:</p>
                     <p>Please click the following link to sign in:</p>
-                    <a href='{}' style="display: inline-block; padding: 10px 20px; background-color: #007bff; color: white; text-decoration: none; border-radius: 4px;">{}</a>
+                    <a href='{link}' style="display: inline-block; padding: 10px 20px; background-color: #007bff; color: white; text-decoration: none; border-radius: 4px;">{link}</a>
                 </div>
             </div>
-            "#,
-            link, link
+            "#
         )),
     )
         .into_response()

--- a/torii-auth-passkey/examples/passkey.rs
+++ b/torii-auth-passkey/examples/passkey.rs
@@ -104,10 +104,7 @@ async fn finish_registration_handler(
             Ok(credential) => credential,
             Err(e) => {
                 tracing::error!("Failed to deserialize credential: {}", e);
-                return (
-                    StatusCode::BAD_REQUEST,
-                    format!("Invalid credential: {}", e),
-                )
+                return (StatusCode::BAD_REQUEST, format!("Invalid credential: {e}"))
                     .into_response();
             }
         };
@@ -135,7 +132,7 @@ async fn finish_registration_handler(
         tracing::error!("Failed to complete registration: {:?}", e);
         (
             StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to complete registration: {}", e),
+            format!("Failed to complete registration: {e}"),
         )
             .into_response()
     })
@@ -288,11 +285,7 @@ async fn finish_login_handler(
         Ok(credential) => credential,
         Err(e) => {
             tracing::error!("Failed to deserialize credential: {}", e);
-            return (
-                StatusCode::BAD_REQUEST,
-                format!("Invalid credential: {}", e),
-            )
-                .into_response();
+            return (StatusCode::BAD_REQUEST, format!("Invalid credential: {e}")).into_response();
         }
     };
 
@@ -319,7 +312,7 @@ async fn finish_login_handler(
         tracing::error!("Failed to complete login: {:?}", e);
         (
             StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to complete login: {}", e),
+            format!("Failed to complete login: {e}"),
         )
             .into_response()
     })

--- a/torii-auth-passkey/src/lib.rs
+++ b/torii-auth-passkey/src/lib.rs
@@ -369,7 +369,7 @@ where
         let passkey_challenge: PasskeyRegistration = serde_json::from_str(&passkey_challenge)
             .map_err(|e| PasskeyError::SerializationError {
                 context: PasskeyErrorContext::Challenge,
-                message: format!("Failed to deserialize challenge: {}", e),
+                message: format!("Failed to deserialize challenge: {e}"),
             })?;
 
         // Finish the passkey registration
@@ -547,7 +547,7 @@ where
         let passkey_challenge: PasskeyAuthentication = serde_json::from_str(&passkey_challenge)
             .map_err(|e| PasskeyError::SerializationError {
                 context: PasskeyErrorContext::Challenge,
-                message: format!("Failed to deserialize challenge: {}", e),
+                message: format!("Failed to deserialize challenge: {e}"),
             })?;
 
         // Finish the passkey login

--- a/torii-core/src/session.rs
+++ b/torii-core/src/session.rs
@@ -76,7 +76,7 @@ impl SessionToken {
         let encoding_key = config.get_encoding_key()?;
 
         let token = encode(&header, claims, &encoding_key)
-            .map_err(|e| SessionError::InvalidToken(format!("Failed to encode JWT: {}", e)))?;
+            .map_err(|e| SessionError::InvalidToken(format!("Failed to encode JWT: {e}")))?;
 
         Ok(SessionToken::Jwt(token))
     }
@@ -90,7 +90,7 @@ impl SessionToken {
 
                 let token_data =
                     decode::<JwtClaims>(token, &decoding_key, &validation).map_err(|e| {
-                        SessionError::InvalidToken(format!("JWT validation failed: {}", e))
+                        SessionError::InvalidToken(format!("JWT validation failed: {e}"))
                     })?;
 
                 Ok(token_data.claims)
@@ -164,8 +164,8 @@ impl From<&str> for SessionToken {
 impl std::fmt::Display for SessionToken {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            SessionToken::Opaque(token) => write!(f, "{}", token),
-            SessionToken::Jwt(token) => write!(f, "{}", token),
+            SessionToken::Opaque(token) => write!(f, "{token}"),
+            SessionToken::Jwt(token) => write!(f, "{token}"),
         }
     }
 }
@@ -256,11 +256,11 @@ impl JwtConfig {
         use std::fs::read;
 
         let private_key = read(private_key_path).map_err(|e| {
-            ValidationError::InvalidField(format!("Failed to read private key file: {}", e))
+            ValidationError::InvalidField(format!("Failed to read private key file: {e}"))
         })?;
 
         let public_key = read(public_key_path).map_err(|e| {
-            ValidationError::InvalidField(format!("Failed to read public key file: {}", e))
+            ValidationError::InvalidField(format!("Failed to read public key file: {e}"))
         })?;
 
         Ok(Self::new_rs256(private_key, public_key))
@@ -302,7 +302,7 @@ impl JwtConfig {
         match &self.algorithm {
             JwtAlgorithm::RS256 { private_key, .. } => EncodingKey::from_rsa_pem(private_key)
                 .map_err(|e| {
-                    ValidationError::InvalidField(format!("Invalid RSA private key: {}", e)).into()
+                    ValidationError::InvalidField(format!("Invalid RSA private key: {e}")).into()
                 }),
             JwtAlgorithm::HS256 { secret_key } => Ok(EncodingKey::from_secret(secret_key)),
         }
@@ -313,7 +313,7 @@ impl JwtConfig {
         match &self.algorithm {
             JwtAlgorithm::RS256 { public_key, .. } => DecodingKey::from_rsa_pem(public_key)
                 .map_err(|e| {
-                    ValidationError::InvalidField(format!("Invalid RSA public key: {}", e)).into()
+                    ValidationError::InvalidField(format!("Invalid RSA public key: {e}")).into()
                 }),
             JwtAlgorithm::HS256 { secret_key } => Ok(DecodingKey::from_secret(secret_key)),
         }
@@ -879,7 +879,7 @@ IwIDAQAB
         if let Err(Error::Session(SessionError::Expired)) = result {
             // This is the expected error
         } else {
-            panic!("Expected SessionError::Expired, got {:?}", result);
+            panic!("Expected SessionError::Expired, got {result:?}");
         }
     }
 }

--- a/torii-storage-postgres/src/lib.rs
+++ b/torii-storage-postgres/src/lib.rs
@@ -271,19 +271,19 @@ mod tests {
         let db_name = format!("torii_test_{}", rand::rng().random_range(1..i64::MAX));
 
         // Drop the database if it exists
-        sqlx::query(format!("DROP DATABASE IF EXISTS {}", db_name).as_str())
+        sqlx::query(format!("DROP DATABASE IF EXISTS {db_name}").as_str())
             .execute(&pool)
             .await
             .expect("Failed to drop database");
 
         // Create a new database for the test
-        sqlx::query(format!("CREATE DATABASE {}", db_name).as_str())
+        sqlx::query(format!("CREATE DATABASE {db_name}").as_str())
             .execute(&pool)
             .await
             .expect("Failed to create database");
 
         let pool = PgPool::connect(
-            format!("postgres://postgres:postgres@localhost:5432/{}", db_name).as_str(),
+            format!("postgres://postgres:postgres@localhost:5432/{db_name}").as_str(),
         )
         .await
         .expect("Failed to create pool");
@@ -301,7 +301,7 @@ mod tests {
             .create_user(
                 &NewUser::builder()
                     .id(id.clone())
-                    .email(format!("test{}@example.com", id))
+                    .email(format!("test{id}@example.com"))
                     .build()
                     .expect("Failed to build user"),
             )

--- a/torii-storage-postgres/src/migrations/mod.rs
+++ b/torii-storage-postgres/src/migrations/mod.rs
@@ -556,19 +556,19 @@ mod tests {
         let db_name = format!("torii_test_{}", rand::rng().random_range(1..i64::MAX));
 
         // Drop the database if it exists
-        sqlx::query(format!("DROP DATABASE IF EXISTS {}", db_name).as_str())
+        sqlx::query(format!("DROP DATABASE IF EXISTS {db_name}").as_str())
             .execute(&pool)
             .await
             .expect("Failed to drop database");
 
         // Create a new database for the test
-        sqlx::query(format!("CREATE DATABASE {}", db_name).as_str())
+        sqlx::query(format!("CREATE DATABASE {db_name}").as_str())
             .execute(&pool)
             .await
             .expect("Failed to create database");
 
         let pool = PgPool::connect(
-            format!("postgres://postgres:postgres@localhost:5432/{}", db_name).as_str(),
+            format!("postgres://postgres:postgres@localhost:5432/{db_name}").as_str(),
         )
         .await
         .expect("Failed to create pool");

--- a/torii-storage-postgres/src/session.rs
+++ b/torii-storage-postgres/src/session.rs
@@ -143,7 +143,7 @@ mod test {
         let user = crate::tests::create_test_user(&storage, &user_id)
             .await
             .expect("Failed to create user");
-        assert_eq!(user.email, format!("test{}@example.com", user_id));
+        assert_eq!(user.email, format!("test{user_id}@example.com"));
 
         let fetched = storage
             .get_user(&user_id)
@@ -151,7 +151,7 @@ mod test {
             .expect("Failed to get user");
         assert_eq!(
             fetched.expect("User should exist").email,
-            format!("test{}@example.com", user_id)
+            format!("test{user_id}@example.com")
         );
 
         storage

--- a/torii-storage-sqlite/src/lib.rs
+++ b/torii-storage-sqlite/src/lib.rs
@@ -307,7 +307,7 @@ mod tests {
             .create_user(
                 &NewUser::builder()
                     .id(UserId::new(id))
-                    .email(format!("test{}@example.com", id))
+                    .email(format!("test{id}@example.com"))
                     .build()
                     .expect("Failed to build user"),
             )

--- a/torii/src/lib.rs
+++ b/torii/src/lib.rs
@@ -53,7 +53,7 @@ use std::sync::Arc;
 use chrono::Duration;
 use torii_core::{
     DefaultUserManager, PluginManager, UserManager,
-    session::{DefaultSessionManager, JwtConfig, JwtSessionManager, SessionManager},
+    session::{DefaultSessionManager, JwtSessionManager, SessionManager},
     storage::{PasswordStorage, SessionStorage, UserStorage},
 };
 
@@ -61,7 +61,7 @@ use torii_core::{
 ///
 /// These types are commonly used when working with the Torii API.
 pub use torii_core::{
-    session::{Session, SessionToken},
+    session::{JwtConfig, Session, SessionToken},
     storage::MagicToken,
     user::{User, UserId},
 };
@@ -868,7 +868,7 @@ where
     ) -> Result<User, ToriiError> {
         // Parse the challenge response
         let response = serde_json::from_value(challenge_response.clone()).map_err(|e| {
-            ToriiError::AuthError(format!("Invalid challenge response format: {}", e))
+            ToriiError::AuthError(format!("Invalid challenge response format: {e}"))
         })?;
 
         let completion = PasskeyRegistrationCompletion {
@@ -970,7 +970,7 @@ where
     ) -> Result<(User, Session), ToriiError> {
         // Parse the challenge response
         let response = serde_json::from_value(challenge_response.clone()).map_err(|e| {
-            ToriiError::AuthError(format!("Invalid challenge response format: {}", e))
+            ToriiError::AuthError(format!("Invalid challenge response format: {e}"))
         })?;
 
         let completion = PasskeyLoginCompletion {


### PR DESCRIPTION
Also includes clippy lint fixed for Rust 1.88

Fixes #51