### PR TITLE
feat: use base58 for encoding IDs

### DIFF
--- a/torii-core/Cargo.toml
+++ b/torii-core/Cargo.toml
@@ -22,6 +22,7 @@ thiserror.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 tokio.workspace = true
+b58 = "0.1.2"
 
 [dev-dependencies]
 tokio.workspace = true

--- a/torii-core/src/id.rs
+++ b/torii-core/src/id.rs
@@ -4,13 +4,12 @@
 //! similar to Stripe's API. IDs are generated with at least 96 bits of entropy
 //! and are URL-safe.
 
-use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
 use rand::{TryRngCore, rngs::OsRng};
 
 /// Generate a prefixed ID with at least 96 bits of entropy
 ///
 /// The ID format is: `{prefix}_{random_string}`
-/// Where the random string is base64 URL-safe encoded without padding.
+/// Where the random string is base58 URL-safe encoded without padding.
 ///
 /// # Arguments
 /// * `prefix` - The prefix for the ID (e.g., "usr", "sess", "tok")
@@ -25,8 +24,8 @@ pub fn generate_prefixed_id(prefix: &str) -> String {
     let mut bytes = [0u8; 12];
     OsRng.try_fill_bytes(&mut bytes).unwrap();
 
-    // Encode to base64 URL-safe without padding
-    let encoded = BASE64_URL_SAFE_NO_PAD.encode(bytes);
+    // Encode to base58 URL-safe without padding
+    let encoded = b58::encode(&bytes);
 
     format!("{prefix}_{encoded}")
 }
@@ -95,7 +94,7 @@ mod tests {
     fn test_generate_prefixed_id() {
         let id = generate_prefixed_id("usr");
         assert!(id.starts_with("usr_"));
-        assert!(id.len() > 4); // prefix + underscore + base64
+        assert!(id.len() > 4); // prefix + underscore + base58
 
         // Ensure uniqueness
         let id2 = generate_prefixed_id("usr");

--- a/torii-core/src/id.rs
+++ b/torii-core/src/id.rs
@@ -47,7 +47,7 @@ pub fn generate_prefixed_id_with_bytes(prefix: &str, bytes: usize) -> String {
     let mut random_bytes = vec![0u8; bytes];
     OsRng.try_fill_bytes(&mut random_bytes).unwrap();
 
-    let encoded = BASE64_URL_SAFE_NO_PAD.encode(random_bytes);
+    let encoded = b58::encode(&random_bytes);
 
     format!("{prefix}_{encoded}")
 }
@@ -70,7 +70,7 @@ pub fn validate_prefixed_id(id: &str, expected_prefix: &str) -> bool {
     let random_part = &id[expected_prefix.len() + 1..];
 
     // Try to decode to ensure it's valid base64
-    match BASE64_URL_SAFE_NO_PAD.decode(random_part) {
+    match b58::decode(random_part) {
         Ok(decoded) => decoded.len() >= 12, // At least 96 bits
         Err(_) => false,
     }
@@ -109,7 +109,7 @@ mod tests {
 
         // Extract and decode the random part
         let random_part = &id[5..]; // "sess_".len() = 5
-        let decoded = BASE64_URL_SAFE_NO_PAD.decode(random_part).unwrap();
+        let decoded = b58::decode(random_part).unwrap();
         assert_eq!(decoded.len(), 16);
     }
 


### PR DESCRIPTION
Instead of URL Safe base64, which still includes `_` and `-`, use base58.

Base58 also excludes 0 (zero), O (capital o), I (capital i) and l (lowercase L) to prevent confusion